### PR TITLE
Add a minimal Docker backend that can start containers

### DIFF
--- a/fishtank/src/backend/docker.test.ts
+++ b/fishtank/src/backend/docker.test.ts
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Docker } from './docker'
+
+describe('Docker Backend', () => {
+  it('throws an error if Docker fails', async () => {
+    const docker = new Docker({ executable: '/this/path/does/not/exist' })
+    await expect(docker.runDetached('hello-world')).rejects.toThrow(
+      "Command '/this/path/does/not/exist run --quiet --detach hello-world' exited with status ENOENT",
+    )
+  })
+
+  describe('runDetached', () => {
+    it('launches the entrypoint of the container by default', async () => {
+      const docker = new Docker()
+      docker['cmd'] = jest.fn()
+
+      await docker.runDetached('hello-world:latest')
+      expect(docker['cmd']).toHaveBeenCalledWith(
+        ['run', '--quiet', '--detach', 'hello-world:latest'],
+        {},
+      )
+    })
+
+    it('passes arguments to the entrypoint of the container', async () => {
+      const docker = new Docker()
+      docker['cmd'] = jest.fn()
+
+      await docker.runDetached('hello-world:latest', { args: ['a', 'b', 'c'] })
+      expect(docker['cmd']).toHaveBeenCalledWith(
+        ['run', '--quiet', '--detach', 'hello-world:latest', 'a', 'b', 'c'],
+        {},
+      )
+    })
+
+    it('gives the container the requested name', async () => {
+      const docker = new Docker()
+      docker['cmd'] = jest.fn()
+
+      await docker.runDetached('hello-world:latest', { name: 'some-name' })
+      expect(docker['cmd']).toHaveBeenCalledWith(
+        ['run', '--quiet', '--detach', '--name', 'some-name', 'hello-world:latest'],
+        {},
+      )
+    })
+
+    it('attaches the container to the requested networks', async () => {
+      const docker = new Docker()
+      docker['cmd'] = jest.fn()
+
+      await docker.runDetached('hello-world:latest', {
+        networks: ['network-a', 'network-b', 'network-c'],
+      })
+      expect(docker['cmd']).toHaveBeenCalledWith(
+        [
+          'run',
+          '--quiet',
+          '--detach',
+          '--network',
+          'network-a',
+          '--network',
+          'network-b',
+          '--network',
+          'network-c',
+          'hello-world:latest',
+        ],
+        {},
+      )
+    })
+  })
+})

--- a/fishtank/src/backend/docker.ts
+++ b/fishtank/src/backend/docker.ts
@@ -1,0 +1,86 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import * as child_process from 'child_process'
+import { ChildProcess, ExecFileOptions } from 'child_process'
+import { promisify } from 'util'
+
+const DEFAULT_COMMAND = 'docker'
+
+type ExecFilePromiseReturn = { child: ChildProcess; stdout: string; stderr: string }
+
+type ExecFilePromiseError = {
+  cmd: string
+  code: number | string
+  stdout: string
+  stderr: string
+}
+
+const execFile = promisify<string, readonly string[], ExecFileOptions, ExecFilePromiseReturn>(
+  child_process.execFile,
+)
+
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access */
+const isExecFilePromiseError = (e: any): e is ExecFilePromiseError => {
+  return (
+    !!e &&
+    typeof e === 'object' &&
+    typeof e['cmd'] === 'string' &&
+    (typeof e['code'] === 'number' || typeof e['code'] === 'string') &&
+    typeof e['stdout'] === 'string' &&
+    typeof e['stderr'] === 'string'
+  )
+}
+
+export class DockerError extends Error {
+  constructor(
+    public readonly command: string,
+    public readonly exitCode: number | string,
+    public stdout: string,
+    public stderr: string,
+  ) {
+    super(`Command '${command}' exited with status ${exitCode}:\n${stderr}`)
+  }
+}
+
+export class Docker {
+  private readonly executable: string
+
+  constructor(options?: { executable?: string }) {
+    this.executable = options?.executable ?? DEFAULT_COMMAND
+  }
+
+  private async cmd(
+    args: readonly string[],
+    options: ExecFileOptions,
+  ): Promise<ExecFilePromiseReturn> {
+    try {
+      return await execFile(this.executable, args, options)
+    } catch (e: unknown) {
+      if (isExecFilePromiseError(e)) {
+        throw new DockerError(e.cmd, e.code, e.stdout, e.stderr)
+      }
+      throw e
+    }
+  }
+
+  async runDetached(
+    image: string,
+    options?: { args?: readonly string[]; name?: string; networks?: readonly string[] },
+  ): Promise<void> {
+    const runArgs = ['run', '--quiet', '--detach']
+    if (options?.name) {
+      runArgs.push('--name', options.name)
+    }
+    if (options?.networks) {
+      for (const network of options.networks) {
+        runArgs.push('--network', network)
+      }
+    }
+    runArgs.push(image)
+    if (options?.args) {
+      runArgs.push(...options.args)
+    }
+    await this.cmd(runArgs, {})
+  }
+}

--- a/fishtank/src/backend/index.ts
+++ b/fishtank/src/backend/index.ts
@@ -1,0 +1,4 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+export * from './docker'


### PR DESCRIPTION
This commit adds a `Docker` class with a `runDetached` method that can spin up new containers in the background. Currently this method supports custom names and networks; in the future it may be extended to support more Docker features.