### PR TITLE
Allow spawning of nodes with custom configuration Part 1

### DIFF
--- a/fishtank/src/backend/docker.test.ts
+++ b/fishtank/src/backend/docker.test.ts
@@ -69,11 +69,14 @@ describe('Docker Backend', () => {
       )
     })
 
-    it('mounts the volume', async () => {
+    it('mounts the volumes', async () => {
       const docker = new Docker()
       docker['cmd'] = jest.fn()
 
-      await docker.runDetached('hello-world:latest', { name: 'some-name', volume: 'file_path' })
+      await docker.runDetached('hello-world:latest', {
+        name: 'some-name',
+        volumes: ['file_path_1', 'file_path_2'],
+      })
       expect(docker['cmd']).toHaveBeenCalledWith(
         [
           'run',
@@ -82,7 +85,9 @@ describe('Docker Backend', () => {
           '--name',
           'some-name',
           '--volume',
-          'file_path',
+          'file_path_1',
+          '--volume',
+          'file_path_2',
           'hello-world:latest',
         ],
         {},

--- a/fishtank/src/backend/docker.test.ts
+++ b/fishtank/src/backend/docker.test.ts
@@ -75,7 +75,10 @@ describe('Docker Backend', () => {
 
       await docker.runDetached('hello-world:latest', {
         name: 'some-name',
-        volumes: ['file_path_1', 'file_path_2'],
+        volumes: new Map<string, string>([
+          ['file_path_1', 'file_path_2'],
+          ['file_path_3', 'file_path_4'],
+        ]),
       })
       expect(docker['cmd']).toHaveBeenCalledWith(
         [
@@ -85,9 +88,9 @@ describe('Docker Backend', () => {
           '--name',
           'some-name',
           '--volume',
-          'file_path_1',
+          'file_path_1:file_path_2',
           '--volume',
-          'file_path_2',
+          'file_path_3:file_path_4',
           'hello-world:latest',
         ],
         {},

--- a/fishtank/src/backend/docker.test.ts
+++ b/fishtank/src/backend/docker.test.ts
@@ -68,6 +68,26 @@ describe('Docker Backend', () => {
         {},
       )
     })
+
+    it('mounts the volume', async () => {
+      const docker = new Docker()
+      docker['cmd'] = jest.fn()
+
+      await docker.runDetached('hello-world:latest', { name: 'some-name', volume: 'file_path' })
+      expect(docker['cmd']).toHaveBeenCalledWith(
+        [
+          'run',
+          '--quiet',
+          '--detach',
+          '--name',
+          'some-name',
+          '--volume',
+          'file_path',
+          'hello-world:latest',
+        ],
+        {},
+      )
+    })
   })
 
   describe('createNetwork', () => {

--- a/fishtank/src/backend/docker.ts
+++ b/fishtank/src/backend/docker.ts
@@ -16,6 +16,13 @@ type ExecFilePromiseError = {
   stderr: string
 }
 
+export type runOption = {
+  args?: readonly string[]
+  name?: string
+  networks?: readonly string[]
+  volume?: string
+}
+
 const execFile = promisify<string, readonly string[], ExecFileOptions, ExecFilePromiseReturn>(
   child_process.execFile,
 )
@@ -64,10 +71,7 @@ export class Docker {
     }
   }
 
-  async runDetached(
-    image: string,
-    options?: { args?: readonly string[]; name?: string; networks?: readonly string[] },
-  ): Promise<void> {
+  async runDetached(image: string, options?: runOption): Promise<void> {
     const runArgs = ['run', '--quiet', '--detach']
     if (options?.name) {
       runArgs.push('--name', options.name)
@@ -77,6 +81,11 @@ export class Docker {
         runArgs.push('--network', network)
       }
     }
+
+    if (options?.volume) {
+      runArgs.push('--volume', options.volume)
+    }
+
     runArgs.push(image)
     if (options?.args) {
       runArgs.push(...options.args)

--- a/fishtank/src/backend/docker.ts
+++ b/fishtank/src/backend/docker.ts
@@ -20,7 +20,7 @@ export type RunOptions = {
   args?: readonly string[]
   name?: string
   networks?: readonly string[]
-  volumes?: readonly string[]
+  volumes?: Map<string, string>
 }
 
 const execFile = promisify<string, readonly string[], ExecFileOptions, ExecFilePromiseReturn>(
@@ -83,8 +83,8 @@ export class Docker {
     }
 
     if (options?.volumes) {
-      for (const volume of options.volumes) {
-        runArgs.push('--volume', volume)
+      for (const entry of options.volumes.entries()) {
+        runArgs.push('--volume', `${entry[0]}:${entry[1]}`)
       }
     }
 

--- a/fishtank/src/backend/docker.ts
+++ b/fishtank/src/backend/docker.ts
@@ -16,11 +16,11 @@ type ExecFilePromiseError = {
   stderr: string
 }
 
-export type runOption = {
+export type RunOptions = {
   args?: readonly string[]
   name?: string
   networks?: readonly string[]
-  volume?: string
+  volumes?: readonly string[]
 }
 
 const execFile = promisify<string, readonly string[], ExecFileOptions, ExecFilePromiseReturn>(
@@ -71,7 +71,7 @@ export class Docker {
     }
   }
 
-  async runDetached(image: string, options?: runOption): Promise<void> {
+  async runDetached(image: string, options?: RunOptions): Promise<void> {
     const runArgs = ['run', '--quiet', '--detach']
     if (options?.name) {
       runArgs.push('--name', options.name)
@@ -82,8 +82,10 @@ export class Docker {
       }
     }
 
-    if (options?.volume) {
-      runArgs.push('--volume', options.volume)
+    if (options?.volumes) {
+      for (const volume of options.volumes) {
+        runArgs.push('--volume', volume)
+      }
     }
 
     runArgs.push(image)

--- a/fishtank/src/cluster.test.ts
+++ b/fishtank/src/cluster.test.ts
@@ -35,10 +35,11 @@ describe('Cluster', () => {
       }
       await cluster.spawn({ name: 'my-test-container', config: nodeConfig })
 
+      const volumes = new Map<string, string>([['~/.test_ironfish', '~/.test_ironfish']])
       expect(runDetached).toHaveBeenCalledWith('ironfish:latest', {
         name: 'my-test-cluster_my-test-container',
         networks: ['my-test-cluster'],
-        volumes: ['~/.test_ironfish'],
+        volumes: volumes,
         args: [
           'start',
           '--networkId=0',

--- a/fishtank/src/cluster.test.ts
+++ b/fishtank/src/cluster.test.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Docker } from './backend'
-import { Cluster } from './cluster'
+import { Cluster, NodeConfig } from './cluster'
 
 describe('Cluster', () => {
   describe('spawn', () => {
@@ -17,6 +17,62 @@ describe('Cluster', () => {
       expect(runDetached).toHaveBeenCalledWith('ironfish:latest', {
         name: 'my-test-cluster_my-test-container',
         networks: ['my-test-cluster'],
+        volume: undefined,
+      })
+    })
+
+    it('launches a detached container with node config', async () => {
+      const backend = new Docker()
+      const cluster = new Cluster({ name: 'my-test-cluster', backend })
+
+      const runDetached = jest.spyOn(backend, 'runDetached').mockReturnValue(Promise.resolve())
+
+      const nodeConfig: NodeConfig = {
+        customNetwork: './test_network.json',
+        networkId: '0',
+        cliconfig: {
+          dataDir: '~/.test_ironfish',
+          configName: './config.json',
+        },
+      }
+      await cluster.spawn({ name: 'my-test-container', config: nodeConfig })
+
+      expect(runDetached).toHaveBeenCalledWith('ironfish:latest', {
+        name: 'my-test-cluster_my-test-container',
+        networks: ['my-test-cluster'],
+        volume: '~/.test_ironfish',
+        args: [
+          '--customNetwork=./test_network.json',
+          '--networkId=0',
+          '--config=./config.json',
+          '--datadir=~/.test_ironfish',
+        ],
+      })
+    })
+
+    it('launches a detached container without datadir', async () => {
+      const backend = new Docker()
+      const cluster = new Cluster({ name: 'my-test-cluster', backend })
+
+      const runDetached = jest.spyOn(backend, 'runDetached').mockReturnValue(Promise.resolve())
+
+      const nodeConfig: NodeConfig = {
+        customNetwork: './test_network.json',
+        networkId: '0',
+        cliconfig: {
+          configName: './config.json',
+        },
+      }
+      await cluster.spawn({ name: 'my-test-container', config: nodeConfig })
+
+      expect(runDetached).toHaveBeenCalledWith('ironfish:latest', {
+        name: 'my-test-cluster_my-test-container',
+        networks: ['my-test-cluster'],
+        args: [
+          '--customNetwork=./test_network.json',
+          '--networkId=0',
+          '--config=./config.json',
+        ],
       })
     })
   })

--- a/fishtank/src/cluster.test.ts
+++ b/fishtank/src/cluster.test.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { existsSync, mkdirSync } from 'fs'
+import { promises } from 'fs'
 import { tmpdir } from 'os'
 import { join, parse } from 'path'
 import { Docker } from './backend'
@@ -11,12 +11,10 @@ describe('Cluster', () => {
   describe('spawn', () => {
     const datadir = `${__dirname}/.ironfish`
 
-    beforeAll(() => {
-      if (!existsSync(datadir)) {
-        mkdirSync(datadir, {
-          recursive: true,
-        })
-      }
+    beforeAll(async () => {
+      await promises.mkdir(datadir, {
+        recursive: true,
+      })
     })
 
     it('launches a detached container with the default image', async () => {
@@ -51,6 +49,7 @@ describe('Cluster', () => {
       const parsedPath = parse(datadir)
       const containerDatadir = join(
         tmpdir(),
+        'fishtank',
         'my-test-cluster_my-test-container',
         parsedPath.name,
       )
@@ -103,6 +102,7 @@ describe('Cluster', () => {
       const parsedPath = parse(datadir)
       const containerDatadir = join(
         tmpdir(),
+        'fishtank',
         'my-test-cluster_my-test-container',
         parsedPath.name,
       )

--- a/fishtank/src/cluster.test.ts
+++ b/fishtank/src/cluster.test.ts
@@ -17,7 +17,6 @@ describe('Cluster', () => {
       expect(runDetached).toHaveBeenCalledWith('ironfish:latest', {
         name: 'my-test-cluster_my-test-container',
         networks: ['my-test-cluster'],
-        volume: undefined,
       })
     })
 
@@ -28,7 +27,6 @@ describe('Cluster', () => {
       const runDetached = jest.spyOn(backend, 'runDetached').mockReturnValue(Promise.resolve())
 
       const nodeConfig: NodeConfig = {
-        customNetwork: './test_network.json',
         networkId: '0',
         cliconfig: {
           dataDir: '~/.test_ironfish',
@@ -40,9 +38,9 @@ describe('Cluster', () => {
       expect(runDetached).toHaveBeenCalledWith('ironfish:latest', {
         name: 'my-test-cluster_my-test-container',
         networks: ['my-test-cluster'],
-        volume: '~/.test_ironfish',
+        volumes: ['~/.test_ironfish'],
         args: [
-          '--customNetwork=./test_network.json',
+          'start',
           '--networkId=0',
           '--config=./config.json',
           '--datadir=~/.test_ironfish',
@@ -57,7 +55,6 @@ describe('Cluster', () => {
       const runDetached = jest.spyOn(backend, 'runDetached').mockReturnValue(Promise.resolve())
 
       const nodeConfig: NodeConfig = {
-        customNetwork: './test_network.json',
         networkId: '0',
         cliconfig: {
           configName: './config.json',
@@ -68,11 +65,7 @@ describe('Cluster', () => {
       expect(runDetached).toHaveBeenCalledWith('ironfish:latest', {
         name: 'my-test-cluster_my-test-container',
         networks: ['my-test-cluster'],
-        args: [
-          '--customNetwork=./test_network.json',
-          '--networkId=0',
-          '--config=./config.json',
-        ],
+        args: ['start', '--networkId=0', '--config=./config.json'],
       })
     })
   })

--- a/fishtank/src/cluster.ts
+++ b/fishtank/src/cluster.ts
@@ -69,7 +69,11 @@ export class Cluster {
 
       if (config.cliconfig) {
         if (config.cliconfig.configName) {
-          args.push(`--config=${config.cliconfig.configName}`)
+          if (config.cliconfig.dataDir) {
+            args.push(`--config=${config.cliconfig.configName}`)
+          } else {
+            throw new Error('Need to set datadir when config name file is provided.')
+          }
         }
 
         if (config.cliconfig.dataDir) {

--- a/fishtank/src/cluster.ts
+++ b/fishtank/src/cluster.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Docker, runOption } from './backend'
+import { Docker, RunOptions } from './backend'
 
 export const DEFAULT_IMAGE = 'ironfish:latest'
 
@@ -22,12 +22,6 @@ export type NodeConfig = {
   The basic shared config for any IronFish command
   */
   cliconfig?: IronFishCliConfig
-
-  /**
-   * Path to a JSON file containing the network definition of a
-   * custom network to connect to
-   */
-  customNetwork?: string
 
   /**
    * Network ID of an official Iron Fish network to connect to
@@ -61,17 +55,13 @@ export class Cluster {
     const name = this.containerName(options.name)
 
     const args: string[] = []
-    const runOptions: runOption = {
+    const runOptions: RunOptions = {
       name,
       networks: [this.networkName()],
     }
 
     if (options?.config) {
       const config = options.config
-
-      if (config.customNetwork) {
-        args.push(`--customNetwork=${config.customNetwork}`)
-      }
 
       if (config.networkId) {
         args.push(`--networkId=${config.networkId}`)
@@ -84,13 +74,13 @@ export class Cluster {
 
         if (config.cliconfig.dataDir) {
           args.push(`--datadir=${config.cliconfig.dataDir}`)
-          runOptions.volume = config.cliconfig.dataDir
+          runOptions.volumes = [config.cliconfig.dataDir]
         }
       }
     }
 
     if (args.length > 0) {
-      runOptions.args = args
+      runOptions.args = ['start'].concat(args)
     }
 
     return this.backend.runDetached(options.image ?? DEFAULT_IMAGE, runOptions)

--- a/fishtank/src/cluster.ts
+++ b/fishtank/src/cluster.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { cpSync, existsSync, mkdirSync } from 'fs'
+import { cpSync, promises } from 'fs'
 import { tmpdir } from 'os'
 import { join, parse } from 'path'
 import { Docker, RunOptions } from './backend'
@@ -82,12 +82,10 @@ export class Cluster {
         if (config.cliconfig.dataDir) {
           const parsedPath = parse(config.cliconfig.dataDir)
 
-          const dest = join(tmpdir(), name, parsedPath.name)
-          if (!existsSync(dest)) {
-            mkdirSync(dest, {
-              recursive: true,
-            })
-          }
+          const dest = join(tmpdir(), 'fishtank', name, parsedPath.name)
+          await promises.mkdir(dest, {
+            recursive: true,
+          })
 
           cpSync(config.cliconfig.dataDir, dest, {
             recursive: true,

--- a/fishtank/src/cluster.ts
+++ b/fishtank/src/cluster.ts
@@ -74,7 +74,9 @@ export class Cluster {
 
         if (config.cliconfig.dataDir) {
           args.push(`--datadir=${config.cliconfig.dataDir}`)
-          runOptions.volumes = [config.cliconfig.dataDir]
+          runOptions.volumes = new Map<string, string>([
+            [config.cliconfig.dataDir, config.cliconfig.dataDir],
+          ])
         }
       }
     }

--- a/fishtank/src/cluster.ts
+++ b/fishtank/src/cluster.ts
@@ -1,9 +1,39 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Docker } from './backend'
+import { Docker, runOption } from './backend'
 
 export const DEFAULT_IMAGE = 'ironfish:latest'
+
+export type IronFishCliConfig = {
+  /**
+  The name of the config file to use
+  */
+  configName?: string
+
+  /**
+  The path to the data directory
+  */
+  dataDir?: string
+}
+
+export type NodeConfig = {
+  /**
+  The basic shared config for any IronFish command
+  */
+  cliconfig?: IronFishCliConfig
+
+  /**
+   * Path to a JSON file containing the network definition of a
+   * custom network to connect to
+   */
+  customNetwork?: string
+
+  /**
+   * Network ID of an official Iron Fish network to connect to
+   */
+  networkId?: string
+}
 
 export class Cluster {
   public readonly name: string
@@ -27,11 +57,42 @@ export class Cluster {
     return this.backend.createNetwork(this.networkName(), { attachable: true, internal: true })
   }
 
-  async spawn(options: { name: string; image?: string }): Promise<void> {
+  async spawn(options: { name: string; image?: string; config?: NodeConfig }): Promise<void> {
     const name = this.containerName(options.name)
-    return this.backend.runDetached(options.image ?? DEFAULT_IMAGE, {
+
+    const args: string[] = []
+    const runOptions: runOption = {
       name,
       networks: [this.networkName()],
-    })
+    }
+
+    if (options?.config) {
+      const config = options.config
+
+      if (config.customNetwork) {
+        args.push(`--customNetwork=${config.customNetwork}`)
+      }
+
+      if (config.networkId) {
+        args.push(`--networkId=${config.networkId}`)
+      }
+
+      if (config.cliconfig) {
+        if (config.cliconfig.configName) {
+          args.push(`--config=${config.cliconfig.configName}`)
+        }
+
+        if (config.cliconfig.dataDir) {
+          args.push(`--datadir=${config.cliconfig.dataDir}`)
+          runOptions.volume = config.cliconfig.dataDir
+        }
+      }
+    }
+
+    if (args.length > 0) {
+      runOptions.args = args
+    }
+
+    return this.backend.runDetached(options.image ?? DEFAULT_IMAGE, runOptions)
   }
 }


### PR DESCRIPTION
This PR allows to pass in certain config when starting the node.
There are two types of config for start cli: 

1. config shared by ironfish cli
  -d, --datadir=<value>        [default: ~/.ironfish] The path to the data dir
  -v, --verbose                Set logging level to verbose
  --config=<value>             [default: config.json] The name of the config file to
                               use
  --[no-]rpc.http              Connect to the RPC over HTTP
  --rpc.http.host=<value>      The HTTP host to listen for connections on
  --rpc.http.port=<value>      The HTTP port to listen for connections on
  --[no-]rpc.ipc               Connect to the RPC over IPC (default)
  --[no-]rpc.tcp               Connect to the RPC over TCP
  --rpc.tcp.host=<value>       The TCP host to listen for connections on
  --rpc.tcp.port=<value>       The TCP port to listen for connections on
  --[no-]rpc.tcp.tls           Encrypt TCP connection to the RPC over TLS

2. config specific to start cmd
-b, --bootstrap=<value>...   Comma-separated addresses of bootstrap nodes to
                               connect to
-c, --customNetwork=<value>  Path to a JSON file containing the network definition
                               of a custom network to connect to
-g, --graffiti=<value>       Set the graffiti for the node
 -i, --networkId=<value>      Network ID of an official Iron Fish network to connect
                               to
-p, --port=<value>           Port to run the local ws server on
--[no-]upgrade               Run migrations when an upgrade is required
  --workers=<value>

In this PR, it enable to the most two common cli config, datadir and config, and two start cli config, network id and customer network. In the next PR, I will add the configs thats defined in config file so user can override it in case of the default config file.  I will also add config of bootstrap node when bootstrap node is ready.