### PR TITLE
Set predictable hostnames to spawned containers

### DIFF
--- a/fishtank/src/backend/docker.test.ts
+++ b/fishtank/src/backend/docker.test.ts
@@ -68,6 +68,29 @@ describe('Docker Backend', () => {
         {},
       )
     })
+
+    it('gives the container the requested hostname', async () => {
+      const docker = new Docker()
+      docker['cmd'] = jest.fn()
+
+      await docker.runDetached('hello-world:latest', {
+        name: 'some-name',
+        hostname: 'some-hostname',
+      })
+      expect(docker['cmd']).toHaveBeenCalledWith(
+        [
+          'run',
+          '--quiet',
+          '--detach',
+          '--name',
+          'some-name',
+          '--hostname',
+          'some-hostname',
+          'hello-world:latest',
+        ],
+        {},
+      )
+    })
   })
 
   describe('list', () => {

--- a/fishtank/src/backend/docker.ts
+++ b/fishtank/src/backend/docker.ts
@@ -68,7 +68,12 @@ export class Docker {
 
   async runDetached(
     image: string,
-    options?: { args?: readonly string[]; name?: string; networks?: readonly string[] },
+    options?: {
+      args?: readonly string[]
+      name?: string
+      networks?: readonly string[]
+      hostname?: string
+    },
   ): Promise<void> {
     const runArgs = ['run', '--quiet', '--detach']
     if (options?.name) {
@@ -78,6 +83,9 @@ export class Docker {
       for (const network of options.networks) {
         runArgs.push('--network', network)
       }
+    }
+    if (options?.hostname) {
+      runArgs.push('--hostname', options.hostname)
     }
     runArgs.push(image)
     if (options?.args) {

--- a/fishtank/src/cluster.test.ts
+++ b/fishtank/src/cluster.test.ts
@@ -17,6 +17,7 @@ describe('Cluster', () => {
       expect(runDetached).toHaveBeenCalledWith('ironfish:latest', {
         name: 'my-test-cluster_my-test-container',
         networks: ['my-test-cluster'],
+        hostname: 'my-test-container',
       })
     })
   })

--- a/fishtank/src/cluster.ts
+++ b/fishtank/src/cluster.ts
@@ -29,12 +29,13 @@ export class Cluster {
   }
 
   async spawn(options: { name: string; image?: string }): Promise<Node> {
-    const name = this.containerName(options.name)
+    const containerName = this.containerName(options.name)
     await this.backend.runDetached(options.image ?? DEFAULT_IMAGE, {
-      name,
+      name: containerName,
       networks: [this.networkName()],
+      hostname: options.name,
     })
-    return new Node(this, name)
+    return new Node(this, containerName)
   }
 
   async teardown(): Promise<void> {


### PR DESCRIPTION
Docker by default assigns random hostnames to containers (derived from the random container ID). This is an obstacle for cross-container communication. This commit changes the code that spawns new containers to set their host name to the node name, so that users can easily address other nodes.