### PR TITLE
Assign labels to Docker resources to mark them as part of a simulated cluster

### DIFF
--- a/fishtank/src/cluster.test.ts
+++ b/fishtank/src/cluster.test.ts
@@ -18,6 +18,7 @@ describe('Cluster', () => {
         name: 'my-test-cluster_my-test-container',
         networks: ['my-test-cluster'],
         hostname: 'my-test-container',
+        labels: { 'fishtank.cluster': 'my-test-cluster' },
       })
     })
   })
@@ -32,8 +33,6 @@ describe('Cluster', () => {
           { id: 'aaaa', name: 'my-test-cluster_node-1', image: 'img' },
           { id: 'bbbb', name: 'my-test-cluster_node-2', image: 'img' },
           { id: 'cccc', name: 'my-test-cluster_node-3', image: 'img' },
-          { id: 'dddd', name: 'another-container', image: 'img' },
-          { id: 'eeee', name: 'yet-another-container', image: 'img' },
         ]),
       )
 
@@ -41,7 +40,9 @@ describe('Cluster', () => {
 
       await cluster.teardown()
 
-      expect(list).toHaveBeenCalled()
+      expect(list).toHaveBeenCalledWith({
+        labels: { 'fishtank.cluster': 'my-test-cluster' },
+      })
       expect(remove).toHaveBeenCalledWith(
         ['my-test-cluster_node-1', 'my-test-cluster_node-2', 'my-test-cluster_node-3'],
         { force: true, volumes: true },


### PR DESCRIPTION
This way, it is possible to unambiguously manage resources without the risk of interfering with existing Docker workloads. Labels may also be used in the future to identify resources that play a special role (e.g. bootstrap nodes vs regular nodes).

### Testing

```
# start a cluster
$ yarn start start abc

# verify that the created network has the proper label
$ docker network inspect abc
...
        "Labels": {
            "fishtank.cluster": "abc"
        }
...

# start a few nodes
$ yarn start spawn --cluster abc node-1
$ yarn start spawn --cluster abc node-2

# check that the node containers have the right labels
$ docker inspect abc_node-1
...
            "Labels": {
                "fishtank.cluster": "abc"
            }
...

# stop the cluster
$ yarn start stop abc

# verify that all networks and containers related to the cluster are gone
$ docker ps -a
$ docker network ls
```