### PR TITLE
Spawn a bootstrap node when the cluster is initialized

### DIFF
--- a/fishtank-cli/src/commands/start.ts
+++ b/fishtank-cli/src/commands/start.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Command, Config } from '@oclif/core'
+import { Command, Config, Flags } from '@oclif/core'
 import { Cluster } from 'fishtank'
 
 export abstract class Start extends Command {
@@ -15,14 +15,22 @@ export abstract class Start extends Command {
     },
   ]
 
+  static flags = {
+    noBootstrap: Flags.boolean({
+      char: 'B',
+      description:
+        'Do not start any bootstrap node and do not mine any block during the creation of the cluster',
+    }),
+  }
+
   constructor(argv: string[], config: Config) {
     super(argv, config)
   }
 
   async run(): Promise<void> {
-    const { args } = await this.parse(Start)
+    const { args, flags } = await this.parse(Start)
     const clusterName = args.name as string
     const cluster = new Cluster({ name: clusterName })
-    return cluster.init()
+    return cluster.init({ bootstrap: !flags.noBootstrap })
   }
 }

--- a/fishtank/src/cluster.test.ts
+++ b/fishtank/src/cluster.test.ts
@@ -5,16 +5,126 @@ import { Docker } from './backend'
 import { Cluster } from './cluster'
 
 describe('Cluster', () => {
-  describe('spawn', () => {
-    it('launches a detached container with the default image', async () => {
+  describe('init', () => {
+    it('creates the network and launches a bootstrap node', async () => {
+      const backend = new Docker()
+      const cluster = new Cluster({ name: 'my-test-cluster', backend })
+
+      const createNetwork = jest
+        .spyOn(backend, 'createNetwork')
+        .mockReturnValue(Promise.resolve())
+      const runDetached = jest.spyOn(backend, 'runDetached').mockReturnValue(Promise.resolve())
+
+      await cluster.init()
+
+      expect(createNetwork).toHaveBeenCalledWith('my-test-cluster', {
+        attachable: true,
+        internal: true,
+        labels: { 'fishtank.cluster': 'my-test-cluster' },
+      })
+      expect(runDetached).toHaveBeenCalledWith('ironfish:latest', {
+        args: ['start'],
+        name: 'my-test-cluster_bootstrap',
+        networks: ['my-test-cluster'],
+        hostname: 'bootstrap',
+        labels: { 'fishtank.cluster': 'my-test-cluster', 'fishtank.node.role': 'bootstrap' },
+      })
+    })
+
+    it('only creates the network if bootstrap was not requested', async () => {
+      const backend = new Docker()
+      const cluster = new Cluster({ name: 'my-test-cluster', backend })
+
+      const createNetwork = jest
+        .spyOn(backend, 'createNetwork')
+        .mockReturnValue(Promise.resolve())
+      const runDetached = jest.spyOn(backend, 'runDetached').mockReturnValue(Promise.resolve())
+
+      await cluster.init({ bootstrap: false })
+
+      expect(createNetwork).toHaveBeenCalledWith('my-test-cluster', {
+        attachable: true,
+        internal: true,
+        labels: { 'fishtank.cluster': 'my-test-cluster' },
+      })
+      expect(runDetached).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('bootstrap', () => {
+    it('launches a bootstrap node', async () => {
       const backend = new Docker()
       const cluster = new Cluster({ name: 'my-test-cluster', backend })
 
       const runDetached = jest.spyOn(backend, 'runDetached').mockReturnValue(Promise.resolve())
 
-      await cluster.spawn({ name: 'my-test-container' })
+      await cluster.bootstrap()
 
       expect(runDetached).toHaveBeenCalledWith('ironfish:latest', {
+        args: ['start'],
+        name: 'my-test-cluster_bootstrap',
+        networks: ['my-test-cluster'],
+        hostname: 'bootstrap',
+        labels: { 'fishtank.cluster': 'my-test-cluster', 'fishtank.node.role': 'bootstrap' },
+      })
+    })
+
+    it('launches a bootstrap node with the given name', async () => {
+      const backend = new Docker()
+      const cluster = new Cluster({ name: 'my-test-cluster', backend })
+
+      const runDetached = jest.spyOn(backend, 'runDetached').mockReturnValue(Promise.resolve())
+
+      await cluster.bootstrap({ nodeName: 'my-bootstrap-node' })
+
+      expect(runDetached).toHaveBeenCalledWith('ironfish:latest', {
+        args: ['start'],
+        name: 'my-test-cluster_my-bootstrap-node',
+        networks: ['my-test-cluster'],
+        hostname: 'my-bootstrap-node',
+        labels: { 'fishtank.cluster': 'my-test-cluster', 'fishtank.node.role': 'bootstrap' },
+      })
+    })
+
+    it('launches a bootstrap node with the given image', async () => {
+      const backend = new Docker()
+      const cluster = new Cluster({ name: 'my-test-cluster', backend })
+
+      const runDetached = jest.spyOn(backend, 'runDetached').mockReturnValue(Promise.resolve())
+
+      await cluster.bootstrap({ nodeImage: 'some-image' })
+
+      expect(runDetached).toHaveBeenCalledWith('some-image', {
+        args: ['start'],
+        name: 'my-test-cluster_bootstrap',
+        networks: ['my-test-cluster'],
+        hostname: 'bootstrap',
+        labels: { 'fishtank.cluster': 'my-test-cluster', 'fishtank.node.role': 'bootstrap' },
+      })
+    })
+  })
+
+  describe('spawn', () => {
+    it('launches a detached container with the default image', async () => {
+      const backend = new Docker()
+      const cluster = new Cluster({ name: 'my-test-cluster', backend })
+
+      const list = jest
+        .spyOn(backend, 'list')
+        .mockReturnValue(
+          Promise.resolve([
+            { id: 'aaaa', name: 'my-test-cluster_my-bootstrap-node', image: 'img' },
+          ]),
+        )
+      const runDetached = jest.spyOn(backend, 'runDetached').mockReturnValue(Promise.resolve())
+
+      await cluster.spawn({ name: 'my-test-container' })
+
+      expect(list).toHaveBeenCalledWith({
+        labels: { 'fishtank.cluster': 'my-test-cluster', 'fishtank.node.role': 'bootstrap' },
+      })
+      expect(runDetached).toHaveBeenCalledWith('ironfish:latest', {
+        args: ['start', '--bootstrap', 'my-bootstrap-node'],
         name: 'my-test-cluster_my-test-container',
         networks: ['my-test-cluster'],
         hostname: 'my-test-container',

--- a/fishtank/src/cluster.ts
+++ b/fishtank/src/cluster.ts
@@ -1,11 +1,19 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Docker } from './backend'
+import { Docker, Labels } from './backend'
 import { Node } from './node'
 
 export const DEFAULT_IMAGE = 'ironfish:latest'
+export const DEFAULT_BOOTSTRAP_NODE_NAME = 'bootstrap'
 export const CLUSTER_LABEL = 'fishtank.cluster'
+export const NODE_ROLE_LABEL = 'fishtank.node.role'
+export const BOOTSTRAP_NODE_ROLE = 'bootstrap'
+
+export type BootstrapOptions = {
+  nodeName?: string
+  nodeImage?: string
+}
 
 export class Cluster {
   public readonly name: string
@@ -25,23 +33,68 @@ export class Cluster {
     return `${this.name}_${name}`
   }
 
-  async init(): Promise<void> {
-    return this.backend.createNetwork(this.networkName(), {
+  async init(options?: { bootstrap?: boolean | BootstrapOptions }): Promise<void> {
+    await this.backend.createNetwork(this.networkName(), {
       attachable: true,
       internal: true,
       labels: { [CLUSTER_LABEL]: this.name },
     })
+
+    if (typeof options?.bootstrap === 'undefined' || options?.bootstrap === true) {
+      return this.bootstrap()
+    } else if (typeof options?.bootstrap === 'object') {
+      return this.bootstrap(options?.bootstrap)
+    }
+  }
+
+  async bootstrap(options?: BootstrapOptions): Promise<void> {
+    await this.internalSpawn({
+      name: options?.nodeName ?? DEFAULT_BOOTSTRAP_NODE_NAME,
+      image: options?.nodeImage,
+      extraLabels: {
+        [NODE_ROLE_LABEL]: BOOTSTRAP_NODE_ROLE,
+      },
+    })
+  }
+
+  private async getBootstrapNodes(): Promise<Node[]> {
+    return (
+      await this.backend.list({
+        labels: {
+          [CLUSTER_LABEL]: this.name,
+          [NODE_ROLE_LABEL]: BOOTSTRAP_NODE_ROLE,
+        },
+      })
+    ).map((container) => new Node(this, container.name.slice(this.name.length + 1)))
   }
 
   async spawn(options: { name: string; image?: string }): Promise<Node> {
+    const extraArgs = []
+    for (const bootstrapNode of await this.getBootstrapNodes()) {
+      extraArgs.push('--bootstrap', bootstrapNode.name)
+    }
+    return this.internalSpawn({ extraArgs, ...options })
+  }
+
+  private async internalSpawn(options: {
+    name: string
+    image?: string
+    extraArgs?: string[]
+    extraLabels?: Labels
+  }): Promise<Node> {
     const containerName = this.containerName(options.name)
+    const args = ['start', ...(options.extraArgs ?? [])]
     await this.backend.runDetached(options.image ?? DEFAULT_IMAGE, {
+      args,
       name: containerName,
       networks: [this.networkName()],
       hostname: options.name,
-      labels: { [CLUSTER_LABEL]: this.name },
+      labels: {
+        [CLUSTER_LABEL]: this.name,
+        ...options.extraLabels,
+      },
     })
-    return new Node(this, containerName)
+    return new Node(this, options.name)
   }
 
   async teardown(): Promise<void> {

--- a/fishtank/src/node.ts
+++ b/fishtank/src/node.ts
@@ -16,7 +16,11 @@ export class Node {
     this.backend = cluster['backend']
   }
 
+  private get containerName(): string {
+    return this.cluster['containerName'](this.name)
+  }
+
   remove(): Promise<void> {
-    return this.backend.remove([this.name], { force: true, volumes: true })
+    return this.backend.remove([this.containerName], { force: true, volumes: true })
   }
 }


### PR DESCRIPTION
A bootstrap node is automatically spawned when calling `init()` (unless this behavior is explicitly disabled).

All subsequently spawned nodes will be connected to the bootstrap node.