### PR TITLE
Spawn a bootstrap node when the cluster is initialized

### DIFF
--- a/fishtank-cli/src/commands/start.ts
+++ b/fishtank-cli/src/commands/start.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Command, Config } from '@oclif/core'
+import { Command, Config, Flags } from '@oclif/core'
 import { Cluster } from 'fishtank'
 
 export abstract class Start extends Command {
@@ -15,14 +15,22 @@ export abstract class Start extends Command {
     },
   ]
 
+  static flags = {
+    noBootstrap: Flags.boolean({
+      char: 'B',
+      description:
+        'Do not start any bootstrap node and do not mine any block during the creation of the cluster',
+    }),
+  }
+
   constructor(argv: string[], config: Config) {
     super(argv, config)
   }
 
   async run(): Promise<void> {
-    const { args } = await this.parse(Start)
+    const { args, flags } = await this.parse(Start)
     const clusterName = args.name as string
     const cluster = new Cluster({ name: clusterName })
-    return cluster.init()
+    return cluster.init({ bootstrap: !flags.noBootstrap })
   }
 }

--- a/fishtank/src/cluster.ts
+++ b/fishtank/src/cluster.ts
@@ -5,11 +5,19 @@ import { ConfigOptions } from '@ironfish/sdk'
 import { promises } from 'fs'
 import { tmpdir } from 'os'
 import { join, resolve } from 'path'
-import { Docker, RunOptions } from './backend'
+import { Docker, Labels, RunOptions } from './backend'
 import { Node } from './node'
 
 export const DEFAULT_IMAGE = 'ironfish:latest'
+export const DEFAULT_BOOTSTRAP_NODE_NAME = 'bootstrap'
 export const CLUSTER_LABEL = 'fishtank.cluster'
+export const NODE_ROLE_LABEL = 'fishtank.node.role'
+export const BOOTSTRAP_NODE_ROLE = 'bootstrap'
+
+export type BootstrapOptions = {
+  nodeName?: string
+  nodeImage?: string
+}
 
 export class Cluster {
   public readonly name: string
@@ -29,12 +37,39 @@ export class Cluster {
     return `${this.name}_${name}`
   }
 
-  async init(): Promise<void> {
-    return this.backend.createNetwork(this.networkName(), {
+  async init(options?: { bootstrap?: boolean | BootstrapOptions }): Promise<void> {
+    await this.backend.createNetwork(this.networkName(), {
       attachable: true,
       internal: true,
       labels: { [CLUSTER_LABEL]: this.name },
     })
+
+    if (typeof options?.bootstrap === 'undefined' || options?.bootstrap === true) {
+      return this.bootstrap()
+    } else if (typeof options?.bootstrap === 'object') {
+      return this.bootstrap(options?.bootstrap)
+    }
+  }
+
+  async bootstrap(options?: BootstrapOptions): Promise<void> {
+    await this.internalSpawn({
+      name: options?.nodeName ?? DEFAULT_BOOTSTRAP_NODE_NAME,
+      image: options?.nodeImage,
+      extraLabels: {
+        [NODE_ROLE_LABEL]: BOOTSTRAP_NODE_ROLE,
+      },
+    })
+  }
+
+  private async getBootstrapNodes(): Promise<Node[]> {
+    return (
+      await this.backend.list({
+        labels: {
+          [CLUSTER_LABEL]: this.name,
+          [NODE_ROLE_LABEL]: BOOTSTRAP_NODE_ROLE,
+        },
+      })
+    ).map((container) => new Node(this, container.name.slice(this.name.length + 1)))
   }
 
   async spawn(options: {
@@ -42,13 +77,28 @@ export class Cluster {
     image?: string
     config?: Partial<ConfigOptions>
   }): Promise<Node> {
+    const extraArgs = []
+    for (const bootstrapNode of await this.getBootstrapNodes()) {
+      extraArgs.push('--bootstrap', bootstrapNode.name)
+    }
+    return this.internalSpawn({ extraArgs, ...options })
+  }
+
+  private async internalSpawn(options: {
+    name: string
+    image?: string
+    config?: Partial<ConfigOptions>
+    extraArgs?: string[]
+    extraLabels?: Labels
+  }): Promise<Node> {
     const containerName = this.containerName(options.name)
 
     const runOptions: RunOptions = {
+      args: ['start', ...(options.extraArgs ?? [])],
       name: containerName,
       networks: [this.networkName()],
       hostname: options.name,
-      labels: { [CLUSTER_LABEL]: this.name },
+      labels: { [CLUSTER_LABEL]: this.name, ...options.extraLabels },
     }
 
     if (options.config) {
@@ -65,7 +115,7 @@ export class Cluster {
     }
 
     await this.backend.runDetached(options.image ?? DEFAULT_IMAGE, runOptions)
-    return new Node(this, containerName)
+    return new Node(this, options.name)
   }
 
   async teardown(): Promise<void> {

--- a/fishtank/src/node.ts
+++ b/fishtank/src/node.ts
@@ -16,7 +16,11 @@ export class Node {
     this.backend = cluster['backend']
   }
 
+  private get containerName(): string {
+    return this.cluster['containerName'](this.name)
+  }
+
   remove(): Promise<void> {
-    return this.backend.remove([this.name], { force: true, volumes: true })
+    return this.backend.remove([this.containerName], { force: true, volumes: true })
   }
 }


### PR DESCRIPTION
A bootstrap node is automatically spawned when calling `init()` (unless this behavior is explicitly disabled).

All subsequently spawned nodes will be connected to the bootstrap node.

(This is a follow-up to PR #13, which was closed by mistake)
