### PR TITLE
Validate cluster and node names

### DIFF
--- a/fishtank/src/cluster.test.ts
+++ b/fishtank/src/cluster.test.ts
@@ -9,6 +9,16 @@ import { Docker } from './backend'
 import { Cluster } from './cluster'
 
 describe('Cluster', () => {
+  describe('constructor', () => {
+    it('refuses to create a cluster with an invalid name', () => {
+      expect(() => new Cluster({ name: '' })).toThrow('Invalid name')
+      expect(() => new Cluster({ name: 'abc def' })).toThrow('Invalid name')
+      expect(() => new Cluster({ name: 'abc:def' })).toThrow('Invalid name')
+      expect(() => new Cluster({ name: 'abc/def' })).toThrow('Invalid name')
+      expect(() => new Cluster({ name: 'abc.def' })).toThrow('Invalid name')
+    })
+  })
+
   describe('init', () => {
     it('creates the network and launches a bootstrap node', async () => {
       const backend = new Docker()

--- a/fishtank/src/naming.ts
+++ b/fishtank/src/naming.ts
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Cluster } from './cluster'
+
+export function isValidName(name: string): boolean {
+  return /^[a-zA-Z0-9_-]+$/.test(name)
+}
+
+export function assertValidName(name: string): void {
+  if (!isValidName(name)) {
+    throw new Error(
+      `Invalid name: ${JSON.stringify(
+        name,
+      )}; names may only contain letters, numbers, underscores or hypens`,
+    )
+  }
+}
+
+/**
+ * Returns the name of the Docker network used for a cluster.
+ */
+export function networkName(cluster: Cluster): string {
+  assertValidName(cluster.name)
+  return cluster.name
+}
+
+/**
+ * Returns the name of the Docker container used to host a node in a cluster.
+ */
+export function containerName(cluster: Cluster, nodeName: string): string {
+  assertValidName(cluster.name)
+  assertValidName(nodeName)
+  return `${cluster.name}_${nodeName}`
+}

--- a/fishtank/src/node.ts
+++ b/fishtank/src/node.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Docker } from './backend'
 import { Cluster } from './cluster'
+import * as naming from './naming'
 
 export class Node {
   public readonly cluster: Cluster
@@ -17,7 +18,7 @@ export class Node {
   }
 
   private get containerName(): string {
-    return this.cluster['containerName'](this.name)
+    return naming.containerName(this.cluster, this.name)
   }
 
   remove(): Promise<void> {


### PR DESCRIPTION
Naming of Docker resources is now delegated to a new `naming` module, which also performs validation.