### PR TITLE
Allow spawning of nodes with custom network definitions

### DIFF
--- a/fishtank/src/cluster.test.ts
+++ b/fishtank/src/cluster.test.ts
@@ -37,7 +37,6 @@ describe('Cluster', () => {
         labels: { 'fishtank.cluster': 'my-test-cluster' },
       })
       expect(runDetached).toHaveBeenCalledWith('ironfish:latest', {
-        args: ['start'],
         name: 'my-test-cluster_bootstrap',
         networks: ['my-test-cluster'],
         hostname: 'bootstrap',
@@ -75,7 +74,6 @@ describe('Cluster', () => {
       await cluster.bootstrap()
 
       expect(runDetached).toHaveBeenCalledWith('ironfish:latest', {
-        args: ['start'],
         name: 'my-test-cluster_bootstrap',
         networks: ['my-test-cluster'],
         hostname: 'bootstrap',
@@ -92,7 +90,6 @@ describe('Cluster', () => {
       await cluster.bootstrap({ nodeName: 'my-bootstrap-node' })
 
       expect(runDetached).toHaveBeenCalledWith('ironfish:latest', {
-        args: ['start'],
         name: 'my-test-cluster_my-bootstrap-node',
         networks: ['my-test-cluster'],
         hostname: 'my-bootstrap-node',
@@ -109,7 +106,6 @@ describe('Cluster', () => {
       await cluster.bootstrap({ nodeImage: 'some-image' })
 
       expect(runDetached).toHaveBeenCalledWith('some-image', {
-        args: ['start'],
         name: 'my-test-cluster_bootstrap',
         networks: ['my-test-cluster'],
         hostname: 'bootstrap',
@@ -178,7 +174,6 @@ describe('Cluster', () => {
       ).toEqual('{"networkId":0}')
 
       expect(runDetached).toHaveBeenCalledWith('ironfish:latest', {
-        args: ['start'],
         name: 'my-test-cluster_my-test-container',
         networks: ['my-test-cluster'],
         hostname: 'my-test-container',

--- a/fishtank/src/cluster.test.ts
+++ b/fishtank/src/cluster.test.ts
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { ConfigOptions } from '@ironfish/sdk'
-import { promises } from 'fs'
+import { existsSync, promises } from 'fs'
 import { tmpdir } from 'os'
 import { join, resolve } from 'path'
 import { Docker } from './backend'
-import { Cluster } from './cluster'
+import { Cluster, NetworkDefinition } from './cluster'
 
 describe('Cluster', () => {
   describe('constructor', () => {
@@ -161,13 +161,16 @@ describe('Cluster', () => {
       const containerDatadir = join(
         tmpdir(),
         'fishtank',
-        'my-test-cluster_my-test-container',
+        'my-test-cluster',
+        'my-test-container',
         '.ironfish',
       )
       const volumes = new Map<string, string>([[containerDatadir, '/root/.ironfish']])
+
       expect(
         await promises.readFile(resolve(containerDatadir, 'config.json'), { encoding: 'utf8' }),
       ).toEqual('{"networkId":0}')
+
       expect(runDetached).toHaveBeenCalledWith('ironfish:latest', {
         args: ['start'],
         name: 'my-test-cluster_my-test-container',
@@ -177,12 +180,102 @@ describe('Cluster', () => {
         volumes: volumes,
       })
     })
+
+    it('launches a detached container with custom network definition', async () => {
+      const backend = new Docker()
+      const cluster = new Cluster({ name: 'my-test-cluster', backend })
+
+      const runDetached = jest.spyOn(backend, 'runDetached').mockReturnValue(Promise.resolve())
+
+      const networkDefinition: Partial<NetworkDefinition> = {
+        id: 0,
+      }
+      const nodeConfig: Partial<ConfigOptions> = {
+        nodeName: 'test node',
+      }
+
+      await cluster.spawn({
+        name: 'my-test-container',
+        networkDefinition: networkDefinition,
+        config: nodeConfig,
+      })
+
+      const containerDatadir = join(
+        tmpdir(),
+        'fishtank',
+        'my-test-cluster',
+        'my-test-container',
+        '.ironfish',
+      )
+      const volumes = new Map<string, string>([[containerDatadir, '/root/.ironfish']])
+
+      expect(
+        await promises.readFile(resolve(containerDatadir, 'customNetwork.json'), {
+          encoding: 'utf8',
+        }),
+      ).toEqual('{"id":0}')
+
+      expect(
+        await promises.readFile(resolve(containerDatadir, 'config.json'), { encoding: 'utf8' }),
+      ).toEqual('{"nodeName":"test node"}')
+
+      expect(runDetached).toHaveBeenCalledWith('ironfish:latest', {
+        name: 'my-test-cluster_my-test-container',
+        networks: ['my-test-cluster'],
+        hostname: 'my-test-container',
+        labels: { 'fishtank.cluster': 'my-test-cluster' },
+        volumes: volumes,
+        args: ['start', '--customNetwork=/root/.ironfish/customNetwork.json'],
+      })
+    })
+
+    it('launches a detached container with custom network definition and node config', async () => {
+      const backend = new Docker()
+      const cluster = new Cluster({ name: 'my-test-cluster', backend })
+
+      const runDetached = jest.spyOn(backend, 'runDetached').mockReturnValue(Promise.resolve())
+
+      const networkDefinition: Partial<NetworkDefinition> = {
+        id: 0,
+      }
+      await cluster.spawn({ name: 'my-test-container', networkDefinition: networkDefinition })
+
+      const containerDatadir = join(
+        tmpdir(),
+        'fishtank',
+        'my-test-cluster',
+        'my-test-container',
+        '.ironfish',
+      )
+      const volumes = new Map<string, string>([[containerDatadir, '/root/.ironfish']])
+      expect(
+        await promises.readFile(resolve(containerDatadir, 'customNetwork.json'), {
+          encoding: 'utf8',
+        }),
+      ).toEqual('{"id":0}')
+      expect(runDetached).toHaveBeenCalledWith('ironfish:latest', {
+        name: 'my-test-cluster_my-test-container',
+        networks: ['my-test-cluster'],
+        hostname: 'my-test-container',
+        labels: { 'fishtank.cluster': 'my-test-cluster' },
+        volumes: volumes,
+        args: ['start', '--customNetwork=/root/.ironfish/customNetwork.json'],
+      })
+    })
   })
 
   describe('teardown', () => {
     it('removes all resources created by the cluster', async () => {
       const backend = new Docker()
       const cluster = new Cluster({ name: 'my-test-cluster', backend })
+
+      jest.spyOn(backend, 'runDetached').mockReturnValue(Promise.resolve())
+
+      const nodeConfig: Partial<ConfigOptions> = {
+        networkId: 0,
+      }
+      await cluster.spawn({ name: 'my-test-container', config: nodeConfig })
+      expect(existsSync(join(tmpdir(), 'fishtank', cluster.name))).toEqual(true)
 
       const list = jest.spyOn(backend, 'list').mockReturnValue(
         Promise.resolve([
@@ -203,6 +296,8 @@ describe('Cluster', () => {
         ['my-test-cluster_node-1', 'my-test-cluster_node-2', 'my-test-cluster_node-3'],
         { force: true, volumes: true },
       )
+
+      expect(existsSync(join(tmpdir(), 'fishtank', cluster.name))).toEqual(false)
     })
   })
 })

--- a/fishtank/src/cluster.test.ts
+++ b/fishtank/src/cluster.test.ts
@@ -119,9 +119,15 @@ describe('Cluster', () => {
   })
 
   describe('spawn', () => {
+    let cluster: Cluster
+
+    afterEach(async () => {
+      await cluster.teardown()
+    })
+
     it('launches a detached container with the default image', async () => {
       const backend = new Docker()
-      const cluster = new Cluster({ name: 'my-test-cluster', backend })
+      cluster = new Cluster({ name: 'my-test-cluster', backend })
 
       const list = jest
         .spyOn(backend, 'list')
@@ -149,7 +155,7 @@ describe('Cluster', () => {
 
     it('launches a detached container with the provided configuration', async () => {
       const backend = new Docker()
-      const cluster = new Cluster({ name: 'my-test-cluster', backend })
+      cluster = new Cluster({ name: 'my-test-cluster', backend })
 
       const runDetached = jest.spyOn(backend, 'runDetached').mockReturnValue(Promise.resolve())
 
@@ -183,12 +189,12 @@ describe('Cluster', () => {
 
     it('launches a detached container with custom network definition', async () => {
       const backend = new Docker()
-      const cluster = new Cluster({ name: 'my-test-cluster', backend })
+      cluster = new Cluster({ name: 'my-test-cluster', backend })
 
       const runDetached = jest.spyOn(backend, 'runDetached').mockReturnValue(Promise.resolve())
 
       const networkDefinition: Partial<NetworkDefinition> = {
-        id: 0,
+        id: 123,
       }
 
       await cluster.spawn({
@@ -209,7 +215,7 @@ describe('Cluster', () => {
         await promises.readFile(resolve(containerDatadir, 'customNetwork.json'), {
           encoding: 'utf8',
         }),
-      ).toEqual('{"id":0}')
+      ).toEqual('{"id":123}')
 
       expect(runDetached).toHaveBeenCalledWith('ironfish:latest', {
         name: 'my-test-cluster_my-test-container',
@@ -223,7 +229,7 @@ describe('Cluster', () => {
 
     it('launches a detached container with custom network definition and node config', async () => {
       const backend = new Docker()
-      const cluster = new Cluster({ name: 'my-test-cluster', backend })
+      cluster = new Cluster({ name: 'my-test-cluster', backend })
 
       const runDetached = jest.spyOn(backend, 'runDetached').mockReturnValue(Promise.resolve())
 

--- a/fishtank/src/cluster.ts
+++ b/fishtank/src/cluster.ts
@@ -147,7 +147,7 @@ export class Cluster {
 
     await this.backend.runDetached(options.image ?? DEFAULT_IMAGE, runOptions)
 
-    return new Node(this, containerName)
+    return node
   }
 
   async teardown(): Promise<void> {

--- a/fishtank/src/node.ts
+++ b/fishtank/src/node.ts
@@ -25,7 +25,7 @@ export class Node {
   }
 
   get dataDir(): string {
-    return join(tmpdir(), 'fishtank', this.containerName, '.ironfish')
+    return join(tmpdir(), 'fishtank', this.cluster.name, this.name, '.ironfish')
   }
 
   get ipcSocketPath(): string {


### PR DESCRIPTION
Temporarily use new `NetworkDefinition` to unblock the dependency of https://github.com/iron-fish/ironfish/pull/4302
Remove cluster folder in teardown

@andiflabs 