### PR TITLE
Make `@ironfish/sdk` a regular dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,10 @@
     "typecheck": "lerna exec -- tsc --noEmit",
     "typecheck:changed": "lerna exec --since origin/master --include-dependents -- tsc --noEmit"
   },
+  "dependencies": {
+    "@ironfish/sdk": "1.9.0"
+  },
   "devDependencies": {
-    "@ironfish/sdk": "1.9.0",
     "@types/jest": "29.2.4",
     "@typescript-eslint/eslint-plugin": "4.28.1",
     "@typescript-eslint/parser": "4.28.1",


### PR DESCRIPTION
`@ironfish/sdk` was accidentally added to `devDependencies`. Move to `dependencies`