### PR TITLE
Pass all options via configuration values

### DIFF
--- a/fishtank/src/cluster.test.ts
+++ b/fishtank/src/cluster.test.ts
@@ -152,13 +152,22 @@ describe('Cluster', () => {
       const runDetached = jest.spyOn(backend, 'runDetached').mockReturnValue(Promise.resolve())
 
       const node = await cluster.spawn({ name: 'my-test-container' })
+      const dataDir = getDataDir('my-test-cluster', 'my-test-container')
 
+      expect(
+        await promises
+          .readFile(resolve(dataDir, 'config.json'), { encoding: 'utf8' })
+          .then(JSON.parse),
+      ).toEqual({
+        networkId: 2,
+        bootstrapNodes: ['my-bootstrap-node'],
+      })
       expect(node.name).toEqual('my-test-container')
       expect(list).toHaveBeenCalledWith({
         labels: { 'fishtank.cluster': 'my-test-cluster', 'fishtank.node.role': 'bootstrap' },
       })
       expect(runDetached).toHaveBeenCalledWith('ironfish:latest', {
-        args: ['start', '--bootstrap', 'my-bootstrap-node'],
+        args: ['start'],
         name: 'my-test-cluster_my-test-container',
         networks: ['my-test-cluster'],
         hostname: 'my-test-container',

--- a/fishtank/src/cluster.ts
+++ b/fishtank/src/cluster.ts
@@ -78,11 +78,11 @@ export class Cluster {
     internal?: Partial<InternalOptions>
     networkDefinition?: Partial<NetworkDefinition>
   }): Promise<Node> {
-    const extraArgs = []
-    for (const bootstrapNode of await this.getBootstrapNodes()) {
-      extraArgs.push('--bootstrap', bootstrapNode.name)
+    const config = options.config || {}
+    if (typeof config.bootstrapNodes === 'undefined') {
+      config.bootstrapNodes = (await this.getBootstrapNodes()).map((node) => node.name)
     }
-    return this.internalSpawn({ extraArgs, ...options })
+    return this.internalSpawn({ ...options, config })
   }
 
   private async internalSpawn(options: {


### PR DESCRIPTION
Pass options using `config.json` rather than using the command line. This allows for more flexibility, as well as type safety.