### PR TITLE
Implement RPC communication on top of the TCP interface

### DIFF
--- a/fishtank-cli/src/commands/start.ts
+++ b/fishtank-cli/src/commands/start.ts
@@ -31,6 +31,7 @@ export abstract class Start extends Command {
     const { args, flags } = await this.parse(Start)
     const clusterName = args.name as string
     const cluster = new Cluster({ name: clusterName })
-    return cluster.init({ bootstrap: !flags.noBootstrap })
+    await cluster.init({ bootstrap: !flags.noBootstrap })
+    this.exit(0)
   }
 }

--- a/fishtank/src/cluster.test.ts
+++ b/fishtank/src/cluster.test.ts
@@ -54,7 +54,6 @@ describe('Cluster', () => {
 
       expect(createNetwork).toHaveBeenCalledWith('my-test-cluster', {
         attachable: true,
-        internal: true,
         labels: { 'fishtank.cluster': 'my-test-cluster' },
       })
       expect(runDetached).toHaveBeenCalledWith('ironfish:latest', {
@@ -62,6 +61,7 @@ describe('Cluster', () => {
         name: 'my-test-cluster_bootstrap',
         networks: ['my-test-cluster'],
         hostname: 'bootstrap',
+        ports: { tcp: [8020] },
         labels: { 'fishtank.cluster': 'my-test-cluster', 'fishtank.node.role': 'bootstrap' },
         volumes: getVolumes('my-test-cluster', 'bootstrap'),
       })
@@ -80,7 +80,6 @@ describe('Cluster', () => {
 
       expect(createNetwork).toHaveBeenCalledWith('my-test-cluster', {
         attachable: true,
-        internal: true,
         labels: { 'fishtank.cluster': 'my-test-cluster' },
       })
       expect(runDetached).not.toHaveBeenCalled()
@@ -101,6 +100,7 @@ describe('Cluster', () => {
         name: 'my-test-cluster_bootstrap',
         networks: ['my-test-cluster'],
         hostname: 'bootstrap',
+        ports: { tcp: [8020] },
         labels: { 'fishtank.cluster': 'my-test-cluster', 'fishtank.node.role': 'bootstrap' },
         volumes: getVolumes('my-test-cluster', 'bootstrap'),
       })
@@ -119,6 +119,7 @@ describe('Cluster', () => {
         name: 'my-test-cluster_my-bootstrap-node',
         networks: ['my-test-cluster'],
         hostname: 'my-bootstrap-node',
+        ports: { tcp: [8020] },
         labels: { 'fishtank.cluster': 'my-test-cluster', 'fishtank.node.role': 'bootstrap' },
         volumes: getVolumes('my-test-cluster', 'my-bootstrap-node'),
       })
@@ -137,6 +138,7 @@ describe('Cluster', () => {
         name: 'my-test-cluster_bootstrap',
         networks: ['my-test-cluster'],
         hostname: 'bootstrap',
+        ports: { tcp: [8020] },
         labels: { 'fishtank.cluster': 'my-test-cluster', 'fishtank.node.role': 'bootstrap' },
         volumes: getVolumes('my-test-cluster', 'bootstrap'),
       })
@@ -173,6 +175,9 @@ describe('Cluster', () => {
           .then(JSON.parse),
       ).toEqual({
         networkId: 2,
+        enableRpcTcp: true,
+        enableRpcTls: false,
+        rpcTcpHost: '',
         bootstrapNodes: ['my-bootstrap-node'],
       })
       expect(node.name).toEqual('my-test-container')
@@ -184,6 +189,7 @@ describe('Cluster', () => {
         name: 'my-test-cluster_my-test-container',
         networks: ['my-test-cluster'],
         hostname: 'my-test-container',
+        ports: { tcp: [8020] },
         labels: { 'fishtank.cluster': 'my-test-cluster' },
         volumes: getVolumes('my-test-cluster', 'my-test-container'),
       })
@@ -212,6 +218,7 @@ describe('Cluster', () => {
         name: 'my-test-cluster_my-test-container',
         networks: ['my-test-cluster'],
         hostname: 'my-test-container',
+        ports: { tcp: [8020] },
         labels: { 'fishtank.cluster': 'my-test-cluster' },
         volumes: getVolumes('my-test-cluster', 'my-test-container'),
       })
@@ -240,6 +247,7 @@ describe('Cluster', () => {
         name: 'my-test-cluster_my-test-container',
         networks: ['my-test-cluster'],
         hostname: 'my-test-container',
+        ports: { tcp: [8020] },
         labels: { 'fishtank.cluster': 'my-test-cluster' },
         volumes: getVolumes('my-test-cluster', 'my-test-container'),
       })
@@ -268,6 +276,7 @@ describe('Cluster', () => {
         name: 'my-test-cluster_my-test-container',
         networks: ['my-test-cluster'],
         hostname: 'my-test-container',
+        ports: { tcp: [8020] },
         labels: { 'fishtank.cluster': 'my-test-cluster' },
         volumes: getVolumes('my-test-cluster', 'my-test-container'),
       })

--- a/fishtank/src/node.test.ts
+++ b/fishtank/src/node.test.ts
@@ -1,8 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { ConfigOptions, FullNode, IronfishSdk } from '@ironfish/sdk'
+import { ConfigOptions, FullNode, IronfishSdk, RpcTcpAdapter } from '@ironfish/sdk'
 import { promises } from 'fs'
+import { AddressInfo } from 'net'
 import { Docker } from './backend'
 import { Cluster } from './cluster'
 import { Node } from './node'
@@ -32,12 +33,42 @@ describe('Node', () => {
       const backend = new Docker()
       const cluster = new Cluster({ name: 'my-test-cluster', backend })
       const node = new Node(cluster, 'my-test-node')
+      const internalNodeName = 'some-random-name-07eb9a7f'
 
       // Start a full node that we can connect to
       await withFullNode(
-        { dataDir: node.dataDir, configOverrides: { nodeName: 'some-random-name-07eb9a7f' } },
-        async (_fullNode) => {
-          // Connect to the node via the IPC socket
+        {
+          dataDir: node.dataDir,
+          configOverrides: {
+            nodeName: internalNodeName,
+            enableRpcTcp: true,
+            enableRpcIpc: false,
+            enableRpcTls: false,
+            rpcTcpPort: 0,
+          },
+        },
+        async (fullNode) => {
+          // Get the TCP port bound by the node
+          let rpcTcpPort = 0
+          for (const adapter of fullNode.rpc.adapters) {
+            if (adapter instanceof RpcTcpAdapter && adapter.server) {
+              rpcTcpPort = (adapter.server.address() as AddressInfo).port
+            }
+          }
+
+          jest.spyOn(backend, 'inspect').mockReturnValue(
+            Promise.resolve({
+              id: 'aaaa',
+              name: internalNodeName,
+              image: 'img',
+              ports: {
+                tcp: new Map<number, number>([[8020, rpcTcpPort]]),
+                udp: new Map<number, number>(),
+              },
+            }),
+          )
+
+          // Connect to the node via the TCP socket
           const rpc = await node.connectRpc()
 
           // Perform some operation over the IPC socket to make sure we are
@@ -47,7 +78,7 @@ describe('Node', () => {
           expect(status).toMatchObject({
             content: {
               node: {
-                nodeName: 'some-random-name-07eb9a7f',
+                nodeName: internalNodeName,
                 status: 'started',
               },
             },


### PR DESCRIPTION
The IPC interface has been replaced with TCP for better interoperability with non-Linux systems