### PR TITLE
Add a method to wait for nodes to start

### DIFF
--- a/fishtank/src/cluster.test.ts
+++ b/fishtank/src/cluster.test.ts
@@ -7,6 +7,7 @@ import { tmpdir } from 'os'
 import { join, resolve } from 'path'
 import { Docker } from './backend'
 import { Cluster } from './cluster'
+import { Node } from './node'
 
 const getDataDir = (clusterName: string, nodeName: string): string => {
   return join(tmpdir(), 'fishtank', clusterName, nodeName, '.ironfish')
@@ -28,6 +29,10 @@ describe('Cluster', () => {
           )}`,
         ),
       )
+  })
+
+  beforeAll(() => {
+    Node.prototype.waitForStart = jest.fn().mockReturnValue(Promise.resolve())
   })
 
   describe('constructor', () => {

--- a/fishtank/src/cluster.ts
+++ b/fishtank/src/cluster.ts
@@ -19,6 +19,7 @@ export const CONTAINER_DATADIR = '/root/.ironfish'
 export type BootstrapOptions = {
   nodeName?: string
   nodeImage?: string
+  waitForStart?: boolean
 }
 
 export type NetworkDefinition = {
@@ -76,6 +77,7 @@ export class Cluster {
     config?: Partial<ConfigOptions>
     internal?: Partial<InternalOptions>
     networkDefinition?: Partial<NetworkDefinition>
+    waitForStart?: boolean
   }): Promise<Node> {
     const config = options.config || {}
     if (typeof config.bootstrapNodes === 'undefined') {
@@ -92,6 +94,7 @@ export class Cluster {
     networkDefinition?: Partial<NetworkDefinition>
     extraArgs?: string[]
     extraLabels?: Labels
+    waitForStart?: boolean
   }): Promise<Node> {
     naming.assertValidName(options.name)
     const node = new Node(this, options.name)
@@ -134,6 +137,10 @@ export class Cluster {
     }
 
     await this.backend.runDetached(options.image ?? DEFAULT_IMAGE, runOptions)
+
+    if (options.waitForStart ?? true) {
+      await node.waitForStart()
+    }
 
     return node
   }

--- a/fishtank/src/node.test.ts
+++ b/fishtank/src/node.test.ts
@@ -28,6 +28,10 @@ const withFullNode = async (
 }
 
 describe('Node', () => {
+  beforeEach(() => {
+    Node.prototype.waitForStart = jest.fn().mockReturnValue(Promise.resolve())
+  })
+
   describe('connectRpc', () => {
     it('connects to the node IPC socket', async () => {
       const backend = new Docker()


### PR DESCRIPTION
This method is invoked automatically when a new node is spawned (and this behavior can be disabled)

Note that this PR may cause the simulator to crash with `Error: read ECONNRESET` in some circumstances. This is due to a bug in the Iron Fish SDK, which does not catch all errors from its client socket, and that in turn causes the entire Node.js process to crash in case an unhandled error occurs. The fix for this bug is in https://github.com/iron-fish/ironfish/pull/4317