### PR TITLE
Update `@ironfish/sdk` to 1.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "typecheck:changed": "lerna exec --since origin/master --include-dependents -- tsc --noEmit"
   },
   "dependencies": {
-    "@ironfish/sdk": "1.9.0"
+    "@ironfish/sdk": "1.10.0"
   },
   "devDependencies": {
     "@types/jest": "29.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -388,62 +388,62 @@
   resolved "https://registry.yarnpkg.com/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz#98c23c950a3d9b6c8f0daed06da6c3af06981340"
   integrity sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==
 
-"@ironfish/rust-nodejs-darwin-arm64@1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@ironfish/rust-nodejs-darwin-arm64/-/rust-nodejs-darwin-arm64-1.8.0.tgz#28e150f7ad51dd6b66fcf995c8476eff62828b0c"
-  integrity sha512-L4hgcIZ25azTQ5WPC4T8rDMh3wu8FZtpPiCD7WRIWbAemE9iKeivQcuBkaFcGd5Bz2B6D4gs01WgCCw+nq3r5w==
-
-"@ironfish/rust-nodejs-darwin-x64@1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@ironfish/rust-nodejs-darwin-x64/-/rust-nodejs-darwin-x64-1.8.0.tgz#7beffda4874fa3d07a45f674f55f3c1e421e8bef"
-  integrity sha512-hqBznqDeSsbZmZZXXvZLq95K/r9xDXVNrlNPqvDKEzcn9kBfC54TXHYiseClV5aJA05o2G7gOWZKTiC10G9YhQ==
-
-"@ironfish/rust-nodejs-linux-arm64-gnu@1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@ironfish/rust-nodejs-linux-arm64-gnu/-/rust-nodejs-linux-arm64-gnu-1.8.0.tgz#cd414b6a9b9457da824b2a766d01373b59465a14"
-  integrity sha512-Y9EAVkXhVwQWhs7WLO0qlIfJtURWNOfvPrzMfXFl5azgQM7qwsTqDIGb1vabLVxhppx+WK70NheTWwYYZ2or9g==
-
-"@ironfish/rust-nodejs-linux-arm64-musl@1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@ironfish/rust-nodejs-linux-arm64-musl/-/rust-nodejs-linux-arm64-musl-1.8.0.tgz#ed1454ef6ff51543518011474dedfd0e439a59fb"
-  integrity sha512-AgrjQA3Rp0ME4CmK8JEqybaiFX+fuyYcIqfE+ZJLOpAtk1J1N0TbfW3x1uJ45UsPNaDvjpi+qyeeWXPhp+yVUA==
-
-"@ironfish/rust-nodejs-linux-x64-gnu@1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@ironfish/rust-nodejs-linux-x64-gnu/-/rust-nodejs-linux-x64-gnu-1.8.0.tgz#3329795f73ab29e580106279f4bd84981770f444"
-  integrity sha512-0MPRhAJ1BmyV/6KcY8ycGTN7AthPN2ieUFp3ggtg/NBcAPZ+3DGMLtgBsKmqvlbTdOW9HVMQBJn3orEo8bPSRQ==
-
-"@ironfish/rust-nodejs-linux-x64-musl@1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@ironfish/rust-nodejs-linux-x64-musl/-/rust-nodejs-linux-x64-musl-1.8.0.tgz#8707c5e128604598627c7e6e9e9ad488ee28b390"
-  integrity sha512-f6lTNU0MCC3ORkM6aGcE4jmjiFH0UEPLZpKv55dWkXlIE8iFDkbzIPzTWpY8iFgJeaG4m6zRvk99oajYGjUQtg==
-
-"@ironfish/rust-nodejs-win32-x64-msvc@1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@ironfish/rust-nodejs-win32-x64-msvc/-/rust-nodejs-win32-x64-msvc-1.8.0.tgz#956e96c3bca88de104fe4d5f315f5b4eaa3d6545"
-  integrity sha512-zyMf4iJr+6Z917PQxLsrA9FOpVrnpaVCZLRVgU6ag4BfU+9vUQElx9f4OSXuzV3M7EHKe73A3ql2UHaqzZCQLQ==
-
-"@ironfish/rust-nodejs@1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@ironfish/rust-nodejs/-/rust-nodejs-1.8.0.tgz#d03d4e92dc1b4d14e8fe49fdeacf78eac5d16b24"
-  integrity sha512-HkCZiuzPpJP4MnWIXfdIjK0DCepuDngoPLECVR9LjFHNMRtT4Z+xrGJeah+j8ME0bMBM/q0675GsgjiiPnz5FA==
-  optionalDependencies:
-    "@ironfish/rust-nodejs-darwin-arm64" "1.8.0"
-    "@ironfish/rust-nodejs-darwin-x64" "1.8.0"
-    "@ironfish/rust-nodejs-linux-arm64-gnu" "1.8.0"
-    "@ironfish/rust-nodejs-linux-arm64-musl" "1.8.0"
-    "@ironfish/rust-nodejs-linux-x64-gnu" "1.8.0"
-    "@ironfish/rust-nodejs-linux-x64-musl" "1.8.0"
-    "@ironfish/rust-nodejs-win32-x64-msvc" "1.8.0"
-
-"@ironfish/sdk@1.9.0":
+"@ironfish/rust-nodejs-darwin-arm64@1.9.0":
   version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@ironfish/sdk/-/sdk-1.9.0.tgz#a6a0a6ecbff406be7b0e3053d0707280d88b26ee"
-  integrity sha512-Os29rWsehLRO359zPu/5KT6n2uL5pvp1n2ri/sZgGMXklh9j4zqPWcoV1OKDDUYiPLMsQ+b9fkTdiGRXQa6RAw==
+  resolved "https://registry.yarnpkg.com/@ironfish/rust-nodejs-darwin-arm64/-/rust-nodejs-darwin-arm64-1.9.0.tgz#61aae2b495367684af369ee6a83a987f87e3d491"
+  integrity sha512-kiwyFZB8jsLeTZIqLFLOcIAgSaybshzdCjnHIRnief5Z0EJkPLt5Ux0k8WcsoKQumST/T9dXyytjnVZyBllcFg==
+
+"@ironfish/rust-nodejs-darwin-x64@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@ironfish/rust-nodejs-darwin-x64/-/rust-nodejs-darwin-x64-1.9.0.tgz#c42f649c7cf6515ef2cc04bc00cee8b3095ef430"
+  integrity sha512-sQe2WMyMSnQNd0GdNfXIQyyzSWtQKVZC7CPmQOeg2a96RScHtwOmPX6hYk6gjs1NIFFXkN+ngRf0iHySBtmDyA==
+
+"@ironfish/rust-nodejs-linux-arm64-gnu@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@ironfish/rust-nodejs-linux-arm64-gnu/-/rust-nodejs-linux-arm64-gnu-1.9.0.tgz#4cf062fd3a0539282451775b4537de90f22c7571"
+  integrity sha512-GZAydmLgtvmdKqLrP10/3c8AOY3vz4/x8xDFX2iRms7KZ4U+R5tWME/wPfXdg0c24GKlKtKBa9e8hB+oH1xQWA==
+
+"@ironfish/rust-nodejs-linux-arm64-musl@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@ironfish/rust-nodejs-linux-arm64-musl/-/rust-nodejs-linux-arm64-musl-1.9.0.tgz#7e58244922892803e71a56b1c88fb8e84b76ab82"
+  integrity sha512-zvTnIXMQK6LzQY4U7NwpPfbr5WbzLSVBV4ZuY6cn/YmSmeDV6ioTs4CQ9AGJNMG4COhkoGVYL4mAcYqd6j6ypw==
+
+"@ironfish/rust-nodejs-linux-x64-gnu@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@ironfish/rust-nodejs-linux-x64-gnu/-/rust-nodejs-linux-x64-gnu-1.9.0.tgz#e4f9bf36af16e56743275236cfe40e1956eb6d9a"
+  integrity sha512-YtEKVc4vU7yLJjUnoRoxOTRN64ipqjzJ2jiewzmTGI1ECx5Fz4YJgn7yHZ90km5CYPGD/pyb3v0dfxrNNeOEjg==
+
+"@ironfish/rust-nodejs-linux-x64-musl@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@ironfish/rust-nodejs-linux-x64-musl/-/rust-nodejs-linux-x64-musl-1.9.0.tgz#ae6de60eb0a1abd2e57b001429e5e13bdc193de7"
+  integrity sha512-z91XjHFoiw8tljtIhJIMLSa1uu61x7Xl37jO7ZxzaOaydD3ufor2GvlSZTC9MFClE3eYfN6ik8mMf7oufs5o0A==
+
+"@ironfish/rust-nodejs-win32-x64-msvc@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@ironfish/rust-nodejs-win32-x64-msvc/-/rust-nodejs-win32-x64-msvc-1.9.0.tgz#0ed9115909ec17b549f52f82100d00328b04f135"
+  integrity sha512-0xCWJAZjRpJlqzVsrFZ670iaZkSlv0HLPorMwhUZbJu/7pYabfU2SPhxon0R/jJ7jHkCAdOvmQ9/SYbZ0UbpzQ==
+
+"@ironfish/rust-nodejs@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@ironfish/rust-nodejs/-/rust-nodejs-1.9.0.tgz#1cfd2b5e630a485c7239f33f5f8545c1dd6825d2"
+  integrity sha512-ZAEzxZ2uFfGVs3bxQ4UAXGROMhr6GSSemH7Ab/SCyDh54fAs9Iu77/IiYPgPS7XfnNLxUix273O8TRTIMoS88g==
+  optionalDependencies:
+    "@ironfish/rust-nodejs-darwin-arm64" "1.9.0"
+    "@ironfish/rust-nodejs-darwin-x64" "1.9.0"
+    "@ironfish/rust-nodejs-linux-arm64-gnu" "1.9.0"
+    "@ironfish/rust-nodejs-linux-arm64-musl" "1.9.0"
+    "@ironfish/rust-nodejs-linux-x64-gnu" "1.9.0"
+    "@ironfish/rust-nodejs-linux-x64-musl" "1.9.0"
+    "@ironfish/rust-nodejs-win32-x64-msvc" "1.9.0"
+
+"@ironfish/sdk@1.10.0":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@ironfish/sdk/-/sdk-1.10.0.tgz#615f9ad5a07a1952e2ac62de3ea5dc0b9a701743"
+  integrity sha512-xI1/kfDKwXX3wJuKtpx5UlbpXTvATMM6P8sPhdnyKYW1FMAiOzLcv5lj6ZC09ip8zwBdfL6/bZJjWiDAh1JEhw==
   dependencies:
     "@ethersproject/bignumber" "5.7.0"
     "@fast-csv/format" "4.3.5"
-    "@ironfish/rust-nodejs" "1.8.0"
+    "@ironfish/rust-nodejs" "1.9.0"
     "@napi-rs/blake-hash" "1.3.3"
     axios "0.21.4"
     bech32 "2.0.0"
@@ -455,6 +455,7 @@
     colors "1.4.0"
     consola "2.15.0"
     date-fns "2.16.1"
+    decimal.js "10.4.3"
     fastpriorityqueue "0.7.1"
     imurmurhash "0.1.4"
     level-errors "2.0.1"
@@ -4002,6 +4003,11 @@ decamelize@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==
+
+decimal.js@10.4.3:
+  version "10.4.3"
+  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.4.3.tgz#1044092884d245d1b7f65725fa4ad4c6f781cc23"
+  integrity sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==
 
 decompress-response@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
The latest SDK release contains a fix (259f052cd9e8f9ce1c379ed31d1d2b286795e9b2) that prevents crashes when connecting to a node's RPC too early after start.