### PR TITLE
Mine 1 block when a cluster is bootstrapped

### DIFF
--- a/fishtank/src/cluster.ts
+++ b/fishtank/src/cluster.ts
@@ -20,6 +20,7 @@ export type BootstrapOptions = {
   nodeName?: string
   nodeImage?: string
   waitForStart?: boolean
+  initChain?: boolean
 }
 
 export type NetworkDefinition = {
@@ -51,13 +52,18 @@ export class Cluster {
   }
 
   async bootstrap(options?: BootstrapOptions): Promise<void> {
-    await this.internalSpawn({
+    const node = await this.internalSpawn({
       name: options?.nodeName ?? DEFAULT_BOOTSTRAP_NODE_NAME,
       image: options?.nodeImage,
+      config: { miningForce: true },
       extraLabels: {
         [NODE_ROLE_LABEL]: BOOTSTRAP_NODE_ROLE,
       },
     })
+
+    if (typeof options?.initChain === 'undefined' || options?.initChain === true) {
+      await node.mineUntil({ blockSequence: 2 })
+    }
   }
 
   private async getBootstrapNodes(): Promise<Node[]> {

--- a/fishtank/src/node.ts
+++ b/fishtank/src/node.ts
@@ -2,19 +2,25 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { IronfishSdk, RpcSocketClient } from '@ironfish/sdk'
+import { randomBytes } from 'crypto'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { Docker } from './backend'
-import { Cluster } from './cluster'
+import { Cluster, CLUSTER_LABEL } from './cluster'
 import * as naming from './naming'
 
 const DEFAULT_WAIT_TIMEOUT = 5 * 1000 // 5 seconds
 const WAIT_POLL_INTERVAL = 200 // 0.2 seconds
+const MINE_POLL_INTERVAL = 200 // 0.2 seconds
 
 export const INTERNAL_RPC_TCP_PORT = 8020
 
 export const sleep = (time: number): Promise<void> => {
   return new Promise((resolve) => setTimeout(resolve, time))
+}
+
+const randomSuffix = (): string => {
+  return randomBytes(2).toString('hex')
 }
 
 export class Node {
@@ -35,6 +41,11 @@ export class Node {
 
   get dataDir(): string {
     return join(tmpdir(), 'fishtank', this.cluster.name, this.name, '.ironfish')
+  }
+
+  async getImage(): Promise<string> {
+    const info = await this.backend.inspect(this.containerName)
+    return info.image
   }
 
   async getRpcTcpPort(): Promise<number> {
@@ -99,6 +110,34 @@ export class Node {
       clearTimeout(timer)
     }
     throw new Error(`Timeout of ${timeout}ms exceeded`)
+  }
+
+  async mineUntil(until: { blockSequence: number }): Promise<void> {
+    const rpc = await this.connectRpc()
+    const isDone = async (): Promise<boolean> => {
+      return (
+        (await rpc.node.getStatus()).content.blockchain.head.sequence >= until.blockSequence
+      )
+    }
+
+    if (await isDone()) {
+      return
+    }
+
+    const minerContainerName = `${this.containerName}-miner-${randomSuffix()}`
+    const minerContainerImage = await this.getImage()
+    await this.backend.runDetached(minerContainerImage, {
+      args: ['miners:start', '--rpc.tcp', '--rpc.tcp.host', this.name, '--no-rpc.tcp.tls'],
+      name: minerContainerName,
+      networks: [naming.networkName(this.cluster)],
+      labels: { [CLUSTER_LABEL]: this.cluster.name },
+    })
+
+    while (!(await isDone())) {
+      await sleep(MINE_POLL_INTERVAL)
+    }
+
+    await this.backend.remove([minerContainerName], { force: true, volumes: true })
   }
 
   remove(): Promise<void> {


### PR DESCRIPTION
When a cluster is bootstrapped, at least 1 block is added on top of the genesis block, so that nodes can consider themselves as synced. This behavior can be disabled.

This also adds the `Node.mineUntil()` method to the simulator SDK, which will be extended further in future commits.

### Testing

Start a new cluster:

```
yarn start start abc
```

Verify that the chain contains a least 2 blocks and that the status is `SYNCED`:

```
$ docker exec abc_bootstrap ironfish status
...
Blockchain           00000063c53685df3c21e298b4cf3c4d8bf283d075a79064000831e47135f27b (2), Since HEAD: 3s 346ms (SYNCED)
```