### PR TITLE
Perform mining through a mining pool

### DIFF
--- a/fishtank/src/cluster.test.ts
+++ b/fishtank/src/cluster.test.ts
@@ -217,6 +217,7 @@ describe('Cluster', () => {
         enableRpcTcp: true,
         enableRpcTls: false,
         rpcTcpHost: '',
+        poolDifficulty: '1500000',
         bootstrapNodes: ['my-bootstrap-node'],
       })
       expect(node.name).toEqual('my-test-container')

--- a/fishtank/src/cluster.ts
+++ b/fishtank/src/cluster.ts
@@ -125,6 +125,7 @@ export class Cluster {
     config.enableRpcTcp ??= true
     config.enableRpcTls ??= false
     config.rpcTcpHost ??= ''
+    config.poolDifficulty ??= '1500000'
 
     await promises.writeFile(resolve(node.dataDir, 'config.json'), JSON.stringify(config))
 


### PR DESCRIPTION
This way, the mining difficulty can be set to a number high enough that makes mining transactions possible.

This is a workaround to the preemptive block template generation that often privileges mining empty blocks, even if transactions are available in the mempool, effectively making it impossible in certain circumstances to mine any transaction. This workaround may be removed (in favor of using a standalone miner) once the preemptive block generation can be disabled.