### PR TITLE
Add a simple simulation that makes a transfer

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "lint:fix": "lerna run lint:fix",
     "lint:ci": "lerna run lint:ci",
     "test": "lerna run test --stream",
+    "simulate": "cd scenarios && yarn simulate",
     "typecheck": "lerna exec -- tsc --noEmit",
     "typecheck:changed": "lerna exec --since origin/master --include-dependents -- tsc --noEmit"
   },

--- a/scenarios/jest.config.js
+++ b/scenarios/jest.config.js
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+const base = require('../jest.config.base')
+const pkg = require('./package.json')
+
+module.exports = {
+  ...base,
+  displayName: pkg.name,
+  testMatch: ['**/*.simulation.ts', '**/*.test.ts']
+}

--- a/scenarios/package.json
+++ b/scenarios/package.json
@@ -29,6 +29,7 @@
     "build": "tsc -b",
     "lint": "tsc -b && eslint --ext .ts,.tsx,.js,.jsx src/",
     "lint:fix": "tsc -b && eslint --ext .ts,.tsx,.js,.jsx src/ --fix",
+    "simulate": "tsc -b && tsc -b tsconfig.test.json && jest --testTimeout=${JEST_TIMEOUT:-60000} --forceExit",
     "clean": "rimraf build"
   },
   "bugs": {

--- a/scenarios/src/index.ts
+++ b/scenarios/src/index.ts
@@ -1,3 +1,93 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { RpcClient } from '@ironfish/sdk'
+import { Cluster } from 'fishtank'
+
+const POLL_INTERVAL = 200 // 0.2 seconds
+
+/**
+ * Return the name of the current Jest test that is being executed. The name is
+ * sanitized to remove special characters so that it can be safely used as a
+ * `Cluster` name.
+ */
+const currentTestName = (): string => {
+  const testName = expect.getState().currentTestName
+  if (!testName) {
+    throw new Error('This method is expected to be called from a Jest test run')
+  }
+  return testName.replace(/\s/g, '-')
+}
+
+/**
+ * Executes a closure with a given `Cluster`.
+ *
+ * The cluster is torn down before calling the closure (to ensure that the
+ * cluster is clean before running any test), and after calling the closure
+ * (for cleanup).
+ */
+export const withCluster = async (
+  cluster: Cluster,
+  callback: (cluster: Cluster) => Promise<void>,
+): Promise<void> => {
+  await cluster.teardown()
+  try {
+    await callback(cluster)
+  } finally {
+    await cluster.teardown()
+  }
+}
+
+/**
+ * Executes a closure with a new test cluster.
+ *
+ * The test cluster is named after the current Jest test that is being
+ * executed.
+ */
+export const withTestCluster = (
+  callback: (cluster: Cluster) => Promise<void>,
+): Promise<void> => {
+  const cluster = new Cluster({ name: currentTestName() })
+  return withCluster(cluster, callback)
+}
+
+/**
+ * Pauses execution for the given number of milliseconds.
+ */
+const sleep = (time: number): Promise<void> => {
+  return new Promise((resolve) => setTimeout(resolve, time))
+}
+
+/**
+ * Waits until the given client is done scanning account transactions.
+ */
+export const waitForScanning = async (client: RpcClient): Promise<void> => {
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const status = await client.node.getStatus()
+    if (status.content.blockchain.head.hash === status.content.accounts.head.hash) {
+      return
+    }
+    await sleep(POLL_INTERVAL)
+  }
+}
+
+/**
+ * Waits until all given clients have their chain in sync with each other.
+ */
+export const waitForSync = async (...clients: RpcClient[]): Promise<void> => {
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const statuses = await Promise.all(clients.map((client) => client.node.getStatus()))
+    const allSynced = statuses
+      .map((status) => status.content.blockchain.synced)
+      .reduce((acc, value) => acc && value, true)
+    if (allSynced) {
+      const heads = new Set(statuses.map((status) => status.content.blockchain.head.hash))
+      if (heads.size <= 1) {
+        return
+      }
+    }
+    await sleep(POLL_INTERVAL)
+  }
+}

--- a/scenarios/src/mineTransaction.simulation.ts
+++ b/scenarios/src/mineTransaction.simulation.ts
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Asset } from '@ironfish/rust-nodejs'
+import { CurrencyUtils } from '@ironfish/sdk'
+import { Cluster } from 'fishtank'
+import { waitForScanning, waitForSync, withTestCluster } from '.'
+
+describe('transactions', () => {
+  it('can be mined', async () => {
+    return withTestCluster(async (cluster: Cluster) => {
+      await cluster.init()
+
+      const node1 = await cluster.spawn({ name: 'node-1' })
+      const node2 = await cluster.spawn({ name: 'node-2' })
+
+      const node1Rpc = await node1.connectRpc()
+      const node2Rpc = await node2.connectRpc()
+
+      await node1.mineUntil({ accountBalance: 200_000_000n })
+
+      const node2Address = (await node2Rpc.wallet.getAccountPublicKey({ account: 'default' }))
+        .content.publicKey
+
+      const createTxResponse = await node1Rpc.wallet.createTransaction({
+        account: 'default',
+        outputs: [
+          {
+            publicAddress: node2Address,
+            amount: CurrencyUtils.encode(100_000_000n),
+            memo: 'some memo',
+            assetId: Asset.nativeId().toString('hex'),
+          },
+        ],
+        fee: CurrencyUtils.encode(500n),
+        expiration: 100,
+      })
+
+      const postTxResponse = await node1Rpc.wallet.postTransaction({
+        transaction: createTxResponse.content.transaction,
+        account: 'default',
+      })
+
+      expect(postTxResponse.content.accepted).toBe(true)
+      expect(postTxResponse.content.broadcasted).toBe(true)
+
+      await node1.mineUntil({ transactionMined: postTxResponse.content.hash })
+      await waitForSync(node1Rpc, node2Rpc)
+      await waitForScanning(node2Rpc)
+
+      const node2BalanceAfterTx = await node2Rpc.wallet.getAccountBalance()
+      expect(BigInt(node2BalanceAfterTx.content.unconfirmed)).toBe(100_000_000n)
+    })
+  })
+})

--- a/scenarios/tsconfig.test.json
+++ b/scenarios/tsconfig.test.json
@@ -1,6 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "noEmit": true
-  }
+    "noEmit": true,
+    "tsBuildInfoFile": "./build/tsconfig.tsbuildinfo"
+  },
+  "include": ["src", "package.json"],
+  "references": []
 }


### PR DESCRIPTION
This simulation:

1. spins up two nodes
2. mines empty blocks on the first node until its default account has 2 $IRON
3. creates a transaction that sends 1 $IRON from the default account of the first node to the default account of the second node
4. mines blocks until the transaction is included in a block
5. verifies that the second node has received the 1 $IRON

The simulation is run as a Jest test in the `simulation` package.

# Testing

Ensure that you have a working installation of Docker, then:

```
yarn simulate
```

# Known Issues

Running a simulation may cause the following messages to be printed:

```
  console.error
    {"errno":-104,"code":"ECONNRESET","syscall":"read"}
```

These messages are printed whenever the code spins up a new node and tries to connect to its RPC interface right away, before the node has started. These are not actually errors, and they are just a sign that the code is waiting for the node to be available. They can be safely ignored. In the future, these messages will be suppressed.