### PR TITLE
On teardown, remove files using a container

### DIFF
--- a/fishtank/src/backend/docker.test.ts
+++ b/fishtank/src/backend/docker.test.ts
@@ -18,6 +18,19 @@ describe('Docker Backend', () => {
     )
   })
 
+  describe('run', () => {
+    it('runs a container, and removes it after its execution is complete', async () => {
+      const docker = new Docker()
+      docker['cmd'] = jest.fn()
+
+      await docker.run('hello-world:latest')
+      expect(docker['cmd']).toHaveBeenCalledWith(
+        ['run', '--quiet', '--rm', 'hello-world:latest'],
+        {},
+      )
+    })
+  })
+
   describe('runDetached', () => {
     it('launches the entrypoint of the container by default', async () => {
       const docker = new Docker()
@@ -26,6 +39,17 @@ describe('Docker Backend', () => {
       await docker.runDetached('hello-world:latest')
       expect(docker['cmd']).toHaveBeenCalledWith(
         ['run', '--quiet', '--detach', 'hello-world:latest'],
+        {},
+      )
+    })
+
+    it('launches the given entrypoint', async () => {
+      const docker = new Docker()
+      docker['cmd'] = jest.fn()
+
+      await docker.runDetached('hello-world:latest', { entrypoint: 'foo' })
+      expect(docker['cmd']).toHaveBeenCalledWith(
+        ['run', '--quiet', '--detach', '--entrypoint', 'foo', 'hello-world:latest'],
         {},
       )
     })


### PR DESCRIPTION
On Linux, processes inside containers run as UID 0 (root) inside their UID namespace. As a result, files and directories created inside containers are owned by root. If the fishtank is not invoked as root, then it will fail to cleanup all files with a "permission denied" error.

This PR fixes the problem by invoking a container to clean up files, rather than trying to delete files directory. The cleanup container will be run with the same privileges as the containers that created those files, so it's guaranteed to succeed.

Note: this problem does not exist on macOS, because on macOS containers are run in a virtual machine, and Docker proxies the creation of files/directories on mounted volumes in a way that makes files/directories owned by the current user. This problem is specific to Linux because containers run natively and there's no proxy layer in between.