### PR TITLE
Do not run simulations in parallel

### DIFF
--- a/fishtank/src/cluster.ts
+++ b/fishtank/src/cluster.ts
@@ -21,6 +21,7 @@ export type BootstrapOptions = {
   nodeImage?: string
   waitForStart?: boolean
   initChain?: boolean
+  networkDefinition?: Partial<NetworkDefinition>
 }
 
 export class Cluster {
@@ -40,10 +41,10 @@ export class Cluster {
       labels: { [CLUSTER_LABEL]: this.name },
     })
 
-    if (options?.bootstrap ?? true) {
-      return this.bootstrap()
-    } else if (typeof options?.bootstrap === 'object') {
+    if (typeof options?.bootstrap === 'object') {
       return this.bootstrap(options?.bootstrap)
+    } else if (options?.bootstrap ?? true) {
+      return this.bootstrap()
     }
   }
 
@@ -56,6 +57,7 @@ export class Cluster {
         [NODE_ROLE_LABEL]: BOOTSTRAP_NODE_ROLE,
       },
       waitForStart: options?.waitForStart,
+      networkDefinition: options?.networkDefinition,
     })
 
     if (options?.initChain ?? true) {

--- a/fishtank/src/cluster.ts
+++ b/fishtank/src/cluster.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { ConfigOptions, InternalOptions } from '@ironfish/sdk'
+import { ConfigOptions, InternalOptions, NetworkDefinition } from '@ironfish/sdk'
 import { promises } from 'fs'
 import { tmpdir } from 'os'
 import { join, resolve } from 'path'
@@ -21,10 +21,6 @@ export type BootstrapOptions = {
   nodeImage?: string
   waitForStart?: boolean
   initChain?: boolean
-}
-
-export type NetworkDefinition = {
-  id: number
 }
 
 export class Cluster {

--- a/scenarios/package.json
+++ b/scenarios/package.json
@@ -29,7 +29,7 @@
     "build": "tsc -b",
     "lint": "tsc -b && eslint --ext .ts,.tsx,.js,.jsx src/",
     "lint:fix": "tsc -b && eslint --ext .ts,.tsx,.js,.jsx src/ --fix",
-    "simulate": "tsc -b && tsc -b tsconfig.test.json && jest --testTimeout=${JEST_TIMEOUT:-60000} --forceExit",
+    "simulate": "tsc -b && tsc -b tsconfig.test.json && jest --runInBand --testTimeout=${JEST_TIMEOUT:-60000} --forceExit",
     "clean": "rimraf build"
   },
   "bugs": {


### PR DESCRIPTION
Simulations are very CPU-intensive and use multiple threads. Running multiple simulations at the same time can severely harm their performance.