### PR TITLE
Disable preemptive block mining

### DIFF
--- a/fishtank/src/cluster.test.ts
+++ b/fishtank/src/cluster.test.ts
@@ -218,6 +218,7 @@ describe('Cluster', () => {
         enableRpcTls: false,
         rpcTcpHost: '',
         poolDifficulty: '1500000',
+        preemptiveBlockMining: false,
         bootstrapNodes: ['my-bootstrap-node'],
       })
       expect(node.name).toEqual('my-test-container')

--- a/fishtank/src/cluster.ts
+++ b/fishtank/src/cluster.ts
@@ -122,6 +122,7 @@ export class Cluster {
     config.enableRpcTls ??= false
     config.rpcTcpHost ??= ''
     config.poolDifficulty ??= '1500000'
+    config.preemptiveBlockMining ??= false
 
     await promises.writeFile(resolve(node.dataDir, 'config.json'), JSON.stringify(config))
 


### PR DESCRIPTION
This forces the miners to mine transactions if the mempool is not empty. As a consequence, all simulations should become 100% reliable.