### PR TITLE
Revert back to using a solo miner

### DIFF
--- a/fishtank/src/cluster.test.ts
+++ b/fishtank/src/cluster.test.ts
@@ -217,7 +217,6 @@ describe('Cluster', () => {
         enableRpcTcp: true,
         enableRpcTls: false,
         rpcTcpHost: '',
-        poolDifficulty: '1500000',
         preemptiveBlockMining: false,
         bootstrapNodes: ['my-bootstrap-node'],
       })

--- a/fishtank/src/cluster.ts
+++ b/fishtank/src/cluster.ts
@@ -121,7 +121,6 @@ export class Cluster {
     config.enableRpcTcp ??= true
     config.enableRpcTls ??= false
     config.rpcTcpHost ??= ''
-    config.poolDifficulty ??= '1500000'
     config.preemptiveBlockMining ??= false
 
     await promises.writeFile(resolve(node.dataDir, 'config.json'), JSON.stringify(config))

--- a/fishtank/src/node.test.ts
+++ b/fishtank/src/node.test.ts
@@ -97,25 +97,6 @@ describe('Node', () => {
       expect(runDetached).toHaveBeenCalledWith(
         'some-image',
         expect.objectContaining({
-          name: expect.stringMatching(/^my-test-cluster_my-test-node-pool-/),
-          args: [
-            'miners:pools:start',
-            '--rpc.tcp',
-            '--rpc.tcp.host',
-            'my-test-node',
-            '--no-rpc.tcp.tls',
-          ],
-          labels: {
-            ['fishtank.cluster']: 'my-test-cluster',
-          },
-          networks: ['my-test-cluster'],
-          hostname: expect.stringMatching(/^my-test-node-pool-/),
-        }),
-      )
-
-      expect(runDetached).toHaveBeenCalledWith(
-        'some-image',
-        expect.objectContaining({
           name: expect.stringMatching(/^my-test-cluster_my-test-node-miner-/),
           args: [
             'miners:start',
@@ -123,19 +104,12 @@ describe('Node', () => {
             '--rpc.tcp.host',
             'my-test-node',
             '--no-rpc.tcp.tls',
-            '--pool',
-            expect.stringMatching(/^my-test-node-pool-/),
           ],
           labels: {
             ['fishtank.cluster']: 'my-test-cluster',
           },
           networks: ['my-test-cluster'],
         }),
-      )
-
-      expect(remove).toHaveBeenCalledWith(
-        [expect.stringMatching(/^my-test-cluster_my-test-node-pool-/)],
-        { force: true },
       )
       expect(remove).toHaveBeenCalledWith(
         [expect.stringMatching(/^my-test-cluster_my-test-node-miner-/)],

--- a/fishtank/src/node.ts
+++ b/fishtank/src/node.ts
@@ -205,28 +205,9 @@ export class Node {
       return
     }
 
-    const poolProcess = await this.spawnCompanionProcess({
-      baseName: 'pool',
-      args: [
-        'miners:pools:start',
-        '--rpc.tcp',
-        '--rpc.tcp.host',
-        this.name,
-        '--no-rpc.tcp.tls',
-      ],
-    })
-
     const minerProcess = await this.spawnCompanionProcess({
       baseName: 'miner',
-      args: [
-        'miners:start',
-        '--rpc.tcp',
-        '--rpc.tcp.host',
-        this.name,
-        '--no-rpc.tcp.tls',
-        '--pool',
-        poolProcess.name,
-      ],
+      args: ['miners:start', '--rpc.tcp', '--rpc.tcp.host', this.name, '--no-rpc.tcp.tls'],
     })
 
     while (!(await isDone())) {
@@ -234,7 +215,6 @@ export class Node {
     }
 
     await minerProcess.remove()
-    await poolProcess.remove()
   }
 
   private async spawnCompanionProcess(options: {


### PR DESCRIPTION
Now that preemptive block mining is disabled, there's no longer the need to use a mining pool with a custom difficulty. A solo miner (with preemptive block mining disabled) can guarantee that pending transactions will be mined as soon as possible.