### PR TITLE
feat(tank): Add CI job to run scenarios

### DIFF
--- a/.github/workflows/run-scenarios.yml
+++ b/.github/workflows/run-scenarios.yml
@@ -1,0 +1,26 @@
+name: Run Scenarios
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v3
+
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.12.1'
+          cache: 'yarn'
+
+      - name: Install packages
+        run: yarn --non-interactive --frozen-lockfile
+
+      - name: Run scenarios
+        run: yarn simulate


### PR DESCRIPTION
Add a workflow which runs every midnight or can be triggered manually to run the test scenarios