### PR TITLE
Suppress RPC connection error messages

### DIFF
--- a/fishtank/src/node.ts
+++ b/fishtank/src/node.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { IronfishSdk, RpcSocketClient } from '@ironfish/sdk'
+import { createRootLogger, IronfishSdk, Logger, RpcSocketClient } from '@ironfish/sdk'
 import { randomBytes } from 'crypto'
 import { tmpdir } from 'os'
 import { join } from 'path'
@@ -50,6 +50,12 @@ const loopWithTimeout = async (
 
 const randomSuffix = (): string => {
   return randomBytes(2).toString('hex')
+}
+
+const dummyLogger = (): Logger => {
+  const logger = createRootLogger()
+  logger.level = -999
+  return logger
 }
 
 export class Node {
@@ -101,6 +107,7 @@ export class Node {
         enableRpcTls: false,
         rpcTcpPort,
       },
+      logger: dummyLogger(),
     })
     return sdk.connectRpc(false, true) as Promise<RpcSocketClient>
   }


### PR DESCRIPTION
When some code tries to connect to the RPC while the node is starting, the RPC client may print errors like this:

```
console.error
    {"errno":-104,"code":"ECONNRESET","syscall":"read"}

      at ConsoleReporter.logText (../node_modules/@ironfish/sdk/build/src/logger/reporters/console.js:53:65)
      at ConsoleReporter.log (../node_modules/@ironfish/sdk/build/src/logger/reporters/text.js:109:14)
      at _log (../node_modules/consola/dist/consola.js:1:8017)
      at t (../node_modules/consola/dist/consola.js:1:7580)
      at _logFn (../node_modules/consola/dist/consola.js:1:7970)
      at _.<anonymous> (../node_modules/consola/dist/consola.js:1:6743)
      at Socket.RpcSocketClient.onSocketError (../node_modules/@ironfish/sdk/build/src/rpc/clients/socketClient.js:131:25)
```

These errors are not a symptom of a bug, so they can be safely suppressed