### PR TITLE
When listing ports bound by Docker, collect only IPv4 addresses

### DIFF
--- a/fishtank/src/backend/docker.test.ts
+++ b/fishtank/src/backend/docker.test.ts
@@ -188,7 +188,7 @@ describe('Docker Backend', () => {
       const docker = new Docker()
       docker['cmd'] = jest.fn().mockReturnValue({
         stdout:
-          '[{"Id":"b19845e77e083ea8ebc191efe3d3bf52e9835fefee04e52582890ef7d8b3821e","Name":"test-cluster_test-node","Config":{"Image":"ironfish:1.3.2"},"NetworkSettings":{"Ports":{"8020/tcp":[{"HostPort":"12345"}]}}}]',
+          '[{"Id":"b19845e77e083ea8ebc191efe3d3bf52e9835fefee04e52582890ef7d8b3821e","Name":"test-cluster_test-node","Config":{"Image":"ironfish:1.3.2"},"NetworkSettings":{"Ports":{"8020/tcp":[{"HostIp":"0.0.0.0","HostPort":"12345"}]}}}]',
       })
 
       const info = await docker.inspect('test-cluster_test-node')

--- a/fishtank/src/backend/docker.ts
+++ b/fishtank/src/backend/docker.ts
@@ -166,7 +166,9 @@ export class Docker {
       if (protocol in ports && bindings) {
         const key = protocol as 'tcp' | 'udp'
         for (const binding of bindings) {
-          ports[key].set(Number(port), Number(binding.HostPort))
+          if (binding.HostIp === '0.0.0.0') {
+            ports[key].set(Number(port), Number(binding.HostPort))
+          }
         }
       }
     }


### PR DESCRIPTION
After a recent update, I've seen that Docker has started to bind different ports for different IP stacks, which leads the `Node.connectRpc()` method sometimes try to connect to the port bound on the IPv6 stack, and apparently our RPC client does not support that, so that fails with an error. This updates the backend so that only ports bound to IPv4 addresses are considered.