### PR TITLE
Increase individual scenario timeout to 30 minutes

### DIFF
--- a/scenarios/package.json
+++ b/scenarios/package.json
@@ -29,7 +29,7 @@
     "build": "tsc -b",
     "lint": "tsc -b && eslint --ext .ts,.tsx,.js,.jsx src/",
     "lint:fix": "tsc -b && eslint --ext .ts,.tsx,.js,.jsx src/ --fix",
-    "simulate": "tsc -b && tsc -b tsconfig.test.json && jest --runInBand --testTimeout=${JEST_TIMEOUT:-600000} --forceExit",
+    "simulate": "tsc -b && tsc -b tsconfig.test.json && jest --runInBand --testTimeout=${JEST_TIMEOUT:-1800000} --forceExit",
     "clean": "rimraf build"
   },
   "bugs": {


### PR DESCRIPTION
Simulations on GitHub Actions run with limited CPU cores, so much more time is needed for them.