### PR TITLE
Print simulations config and node version before each run

### DIFF
--- a/fishtank/src/cluster.ts
+++ b/fishtank/src/cluster.ts
@@ -77,6 +77,16 @@ export class Cluster {
     ).map((container) => new Node(this, container.name.slice(this.name.length + 1)))
   }
 
+  async getNodeVersion(options?: { image?: string }): Promise<string> {
+    const image = options?.image ?? getConfig().defaultImage
+    const { stdout } = await this.backend.run(image, {
+      args: ['version'],
+      name: naming.containerName(this, 'version'),
+      labels: { [CLUSTER_LABEL]: this.name },
+    })
+    return stdout
+  }
+
   async spawn(options: {
     name: string
     image?: string

--- a/scenarios/jest.config.js
+++ b/scenarios/jest.config.js
@@ -7,5 +7,6 @@ const pkg = require('./package.json')
 module.exports = {
   ...base,
   displayName: pkg.name,
-  testMatch: ['**/*.simulation.ts', '**/*.test.ts']
+  testMatch: ['**/*.simulation.ts', '**/*.test.ts'],
+  globalSetup: './build/src/setup.js',
 }

--- a/scenarios/src/setup.ts
+++ b/scenarios/src/setup.ts
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Cluster } from 'fishtank'
+import { getTestConfig } from './config'
+
+/* eslint-disable no-console */
+export default async function (): Promise<void> {
+  console.log()
+  console.log('Configuration:')
+  console.log(JSON.stringify(getTestConfig(), null, 2))
+  console.log()
+  console.log('Node version:')
+  console.log(await new Cluster({ name: 'fishtank-scenarios-setup' }).getNodeVersion())
+}


### PR DESCRIPTION
This way it'll be easier to know at a glance what is being tested. This can be especially useful for GitHub CI runs.

Example output:

    Configuration:
    {
      "defaultImage": "ironfish:latest",
      "extraStartArgs": [],
      "cleanup": true
    }

    Node version:
    name       ironfish
    version    1.12.0
    git        src
    runtime    node/20.9.0