### PR TITLE
Rename "hardFork1" to "assetOwnershipHardFork"

### DIFF
--- a/scenarios/src/assetOwnershipHardFork.simulation.ts
+++ b/scenarios/src/assetOwnershipHardFork.simulation.ts
@@ -193,7 +193,7 @@ const expectChainFork = async (
   }
 }
 
-describe('hard fork 1', () => {
+describe('asset ownership', () => {
   it('v2 transactions are activated after enableAssetOwnership', async () => {
     return withTestCluster(async (cluster: Cluster) => {
       const hardForkHeight = 30


### PR DESCRIPTION
This hard fork didn't end up being the first hard fork, and it's also no longer scheduled, hence renaming.