### PR TITLE
spawns nodes with IPC disabled by default

### DIFF
--- a/fishtank/src/cluster.test.ts
+++ b/fishtank/src/cluster.test.ts
@@ -219,6 +219,7 @@ describe('Cluster', () => {
           .then(JSON.parse),
       ).toEqual({
         enableRpcTcp: true,
+        enableRpcIpc: false,
         enableRpcTls: false,
         rpcTcpHost: '',
         preemptiveBlockMining: false,

--- a/fishtank/src/cluster.ts
+++ b/fishtank/src/cluster.ts
@@ -130,8 +130,8 @@ export class Cluster {
 
     const config = structuredClone(options.config) || {}
     config.enableRpcTcp ??= true
-    config.enableRpcTls ??= false
     config.enableRpcIpc ??= false
+    config.enableRpcTls ??= false
     config.rpcTcpHost ??= ''
     config.preemptiveBlockMining ??= false
 

--- a/fishtank/src/cluster.ts
+++ b/fishtank/src/cluster.ts
@@ -131,6 +131,7 @@ export class Cluster {
     const config = structuredClone(options.config) || {}
     config.enableRpcTcp ??= true
     config.enableRpcTls ??= false
+    config.enableRpcIpc ??= false
     config.rpcTcpHost ??= ''
     config.preemptiveBlockMining ??= false
 

--- a/fishtank/src/node.test.ts
+++ b/fishtank/src/node.test.ts
@@ -33,7 +33,7 @@ describe('Node', () => {
   })
 
   describe('connectRpc', () => {
-    it('connects to the node IPC socket', async () => {
+    it('connects to the node TCP socket', async () => {
       const backend = new Docker()
       const cluster = new Cluster({ name: 'my-test-cluster', backend })
       const node = new Node(cluster, 'my-test-node')


### PR DESCRIPTION
avoids permissions issues listening on IPC socket:

```
Error: listen EPERM: operation not permitted /root/.ironfish/ironfish.ipc
```

rpc connections use TCP instead of IPC in fishtank, so IPC does not need to be enabled by default